### PR TITLE
Propagate current gRPC Context inside call environment

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
-      "io.grpc" % "grpc-services" % grpcVersion
+      "io.grpc" % "grpc-services" % grpcVersion,
+      "io.grpc" % "grpc-context"  % grpcVersion
     )
   )
   .jsConfigure(

--- a/core/js/src/main/scala/io/grpc/Context.scala
+++ b/core/js/src/main/scala/io/grpc/Context.scala
@@ -1,0 +1,11 @@
+package io.grpc
+
+/**
+  * Dummy io.grpc.Context definition for interop with ZServerCallHandler
+  */
+class Context
+
+object Context {
+  val ROOT: Context      = new Context()
+  def current(): Context = ROOT
+}

--- a/core/shared/src/main/scala/scalapb/zio_grpc/RequestContext.scala
+++ b/core/shared/src/main/scala/scalapb/zio_grpc/RequestContext.scala
@@ -1,25 +1,26 @@
 package scalapb.zio_grpc
 
-import io.grpc.MethodDescriptor
-import io.grpc.Attributes
-import io.grpc.ServerCall
+import io.grpc.{Attributes, Context, MethodDescriptor, ServerCall}
 
 final case class RequestContext(
     metadata: SafeMetadata,
     authority: Option[String],
     methodDescriptor: MethodDescriptor[_, _],
-    attributes: Attributes
+    attributes: Attributes,
+    context: Context
 )
 
 object RequestContext {
   def fromServerCall[Req, Res](
       metadata: SafeMetadata,
-      sc: ServerCall[Req, Res]
+      sc: ServerCall[Req, Res],
+      context: Context
   ): RequestContext =
     RequestContext(
       metadata,
       Option(sc.getAuthority()),
       sc.getMethodDescriptor(),
-      sc.getAttributes()
+      sc.getAttributes(),
+      context
     )
 }


### PR DESCRIPTION
Hello, @thesamet 

I've encountered a problem while integrating my service with a third-party (opentracing) `ServerCallInterceptor`, which propagates actual `Span` via gRPC `Context` mechanism.

Unfortunately, `Context.current()` is unavailable inside service implementation because it's backed by `ThreadLocal` inside gRPC and needs to be propagated from calling gRPC thread.

This tiny change allows us to capture current `Context` inside `RequestContext` environment.

I didn't know what to do with Scala.js dependency and added a dummy definition for it just like you did for Metadata in `scalapb-grpcweb`.

Hope you can look into it soon.

Cheers,
Andrey