### PR TITLE
Add Enum response streaming test

### DIFF
--- a/e2e/src/main/protobuf/testservice.proto
+++ b/e2e/src/main/protobuf/testservice.proto
@@ -18,10 +18,20 @@ message Response {
     string out = 1;
 }
 
+message EnumResponse {
+    enum Mood {
+        HAPPY = 0;
+        SAD = 1;
+    }
+    Mood status = 1;
+}
+
 service TestService {
     rpc Unary(Request) returns (Response);
 
     rpc ServerStreaming(Request) returns (stream Response);
+    
+    rpc ServerEnumStreaming(Request) returns (stream EnumResponse);
 
     rpc ClientStreaming(stream Request) returns (Response);
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
@@ -5,7 +5,7 @@ import zio.Has
 import zio.clock.Clock
 import zio.console.Console
 import io.grpc.Status
-import scalapb.zio_grpc.testservice.{Request, Response}
+import scalapb.zio_grpc.testservice.{EnumResponse, Request, Response}
 import zio.ZIO
 import zio.stream.ZStream
 import io.grpc.ServerBuilder
@@ -28,6 +28,8 @@ object BindableServiceSpec extends DefaultRunnableSpec {
     def unary(request: Request): ZIO[R with C, Status, Response] = ???
 
     def serverStreaming(request: Request): ZStream[R with C, Status, Response] = ???
+
+    def serverEnumStreaming(request: Request): ZStream[R with C, Status, EnumResponse] = ???
 
     def clientStreaming(request: zio.stream.ZStream[Any, Status, Request]): ZIO[R with C, Status, Response] = ???
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
@@ -34,6 +34,10 @@ object EnvSpec extends DefaultRunnableSpec with MetadataTests {
         )
       }
 
+    def serverEnumStreaming(
+        request: Request
+    ): ZStream[Console with Has[User], Status, EnumResponse] = ???
+
     def clientStreaming(
         request: zio.stream.ZStream[Any, Status, Request]
     ): ZIO[Has[User], Status, Response] = getUser.map(n => Response(n.name))

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestServiceSpec.scala
@@ -98,6 +98,15 @@ object TestServiceSpec extends DefaultRunnableSpec {
           )
         )(equalTo((List(Response("X1"), Response("X2")), None)))
       },
+      testM("returns successful response with enum") {
+        assertM(
+          collectWithError(
+            TestServiceClient.serverEnumStreaming(
+              Request(Request.Scenario.OK, in = 12)
+            )
+          )
+        )(equalTo((List(EnumResponse(EnumResponse.Mood.HAPPY), EnumResponse(EnumResponse.Mood.SAD)), None)))
+      },
       testM("returns correct error response") {
         assertM(
           collectWithError(


### PR DESCRIPTION
Hello 

I found a bug in `0.4.0+23-d66c1d7d-SNAPSHOT`. It fails to send a correct response for the following message:
```bash
service HealthService {
  rpc getHealth(google.protobuf.Empty) returns (stream HealthResp) {}
}

message HealthResp {
  enum HStatus {
    SERVING = 0;
    FAILED = 1;
    UNKNOWN = 2;
  }
  HStatus health = 1;
  // string health = 1;
}
```
In my app, I'm getting an empty response for `HStatus`, whereas for `string` all works fine. 
I added an `enum` `stream` response to your test suite. I was unable to reproduce that bug thou

I'll proceed to dig into this problem. However, extra test should be fine for this project

Best,
Boris