### PR TITLE
Fix clientStreamingCall for infinite stream

### DIFF
--- a/core/jvm/src/main/scala/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/jvm/src/main/scala/scalapb/zio_grpc/client/ClientCalls.scala
@@ -99,11 +99,14 @@ object ClientCalls {
       req: ZStream[R0, Status, Req]
   ): ZIO[R with R0, Status, Res] =
     ZIO.bracketExit(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
+      val callStream = req.tap(call.sendMessage).drain ++ ZStream.fromEffect(call.halfClose()).drain
+      val resultStream = ZStream.fromEffect(listener.getValue)
+
       call.start(listener, headers) *>
         call.request(1) *>
-        req.foreach(call.sendMessage) *>
-        call.halfClose() *>
-        listener.getValue.map(_._2)
+        callStream.merge(resultStream)
+          .runCollect
+          .map(res => res.last._2)
     }
 
   def bidiCall[R, R0, Req, Res](


### PR DESCRIPTION
Hello
I've founded a problem with scalapb.zio_grpc.client.ClientCalls#clientStreamingCall for potentialy infinite stream. Sending effect can't fail until request stream ends. Small fix to affect the request stream when ClientCall.Listener is closed.
Thx