### PR TITLE
Lift channel.newCall into effect to avoid capturing stateful instance of call

### DIFF
--- a/core/jvm/src/main/scala/scalapb/zio_grpc/ZChannel.scala
+++ b/core/jvm/src/main/scala/scalapb/zio_grpc/ZChannel.scala
@@ -3,9 +3,8 @@ package scalapb.zio_grpc
 import io.grpc.CallOptions
 import io.grpc.MethodDescriptor
 import scalapb.zio_grpc.client.ZClientCall
-import zio.ZIO
+import zio.{Task, UIO, ZIO}
 import io.grpc.ManagedChannel
-import zio.Task
 
 class ZChannel[-R](
     private[zio_grpc] val channel: ManagedChannel,
@@ -14,7 +13,7 @@ class ZChannel[-R](
   def newCall[Req, Res](
       methodDescriptor: MethodDescriptor[Req, Res],
       options: CallOptions
-  ): Task[ZClientCall[R, Req, Res]] = Task.effect(
+  ): UIO[ZClientCall[R, Req, Res]] = ZIO.effectTotal(
     interceptors.foldLeft[ZClientCall[R, Req, Res]](
       ZClientCall(channel.newCall(methodDescriptor, options))
     )((call, interceptor) => interceptor.interceptCall(methodDescriptor, options, call))

--- a/core/jvm/src/main/scala/scalapb/zio_grpc/ZChannel.scala
+++ b/core/jvm/src/main/scala/scalapb/zio_grpc/ZChannel.scala
@@ -14,10 +14,11 @@ class ZChannel[-R](
   def newCall[Req, Res](
       methodDescriptor: MethodDescriptor[Req, Res],
       options: CallOptions
-  ): ZClientCall[R, Req, Res] =
+  ): Task[ZClientCall[R, Req, Res]] = Task.effect(
     interceptors.foldLeft[ZClientCall[R, Req, Res]](
       ZClientCall(channel.newCall(methodDescriptor, options))
     )((call, interceptor) => interceptor.interceptCall(methodDescriptor, options, call))
+  )
 
   def shutdown(): Task[Unit] = ZIO.effect(channel.shutdown()).unit
 

--- a/core/jvm/src/main/scala/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/jvm/src/main/scala/scalapb/zio_grpc/client/ClientCalls.scala
@@ -32,7 +32,9 @@ object ClientCalls {
       headers: SafeMetadata,
       req: Req
   ): ZIO[R, Status, Res] =
-    unaryCall(channel.newCall(method, options), headers, req)
+    ZIO
+      .effectTotal(channel.newCall(method, options))
+      .flatMap(unaryCall(_, headers, req))
 
   private def unaryCall[R, Req, Res](
       call: ZClientCall[R, Req, Res],
@@ -54,11 +56,11 @@ object ClientCalls {
       headers: SafeMetadata,
       req: Req
   ): ZStream[R, Status, Res] =
-    serverStreamingCall(
-      channel.newCall(method, options),
-      headers,
-      req
-    )
+    Stream
+      .fromEffect(
+        ZIO.effectTotal(channel.newCall(method, options))
+      )
+      .flatMap(serverStreamingCall(_, headers, req))
 
   private def serverStreamingCall[R, Req, Res](
       call: ZClientCall[R, Req, Res],
@@ -87,11 +89,15 @@ object ClientCalls {
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
   ): ZIO[R with R0, Status, Res] =
-    clientStreamingCall(
-      channel.newCall(method, options),
-      headers,
-      req
-    )
+    ZIO
+      .effectTotal(channel.newCall(method, options))
+      .flatMap(
+        clientStreamingCall(
+          _,
+          headers,
+          req
+        )
+      )
 
   private def clientStreamingCall[R, R0, Req, Res](
       call: ZClientCall[R, Req, Res],
@@ -117,7 +123,11 @@ object ClientCalls {
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
   ): ZStream[R with R0, Status, Res] =
-    bidiCall(channel.newCall(method, options), headers, req)
+    Stream
+      .fromEffect(
+        ZIO.effectTotal(channel.newCall(method, options))
+      )
+      .flatMap(bidiCall(_, headers, req))
 
   private def bidiCall[R, R0, Req, Res](
       call: ZClientCall[R, Req, Res],

--- a/core/jvm/src/main/scala/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/jvm/src/main/scala/scalapb/zio_grpc/client/ClientCalls.scala
@@ -1,14 +1,9 @@
 package scalapb.zio_grpc.client
 
-import io.grpc.CallOptions
-import zio.Exit
-import zio.ZIO
-import io.grpc.Status
-import zio.stream.Stream
-import io.grpc.MethodDescriptor
-import scalapb.zio_grpc.ZChannel
-import zio.stream.ZStream
-import scalapb.zio_grpc.SafeMetadata
+import io.grpc.{CallOptions, MethodDescriptor, Status}
+import scalapb.zio_grpc.{SafeMetadata, ZChannel}
+import zio.stream.{Stream, ZStream}
+import zio.{Exit, ZIO}
 
 object ClientCalls {
   def exitHandler[R, Req, Res](
@@ -32,8 +27,8 @@ object ClientCalls {
       headers: SafeMetadata,
       req: Req
   ): ZIO[R, Status, Res] =
-    ZIO
-      .effectTotal(channel.newCall(method, options))
+    channel
+      .newCall(method, options)
       .flatMap(unaryCall(_, headers, req))
 
   private def unaryCall[R, Req, Res](
@@ -57,9 +52,7 @@ object ClientCalls {
       req: Req
   ): ZStream[R, Status, Res] =
     Stream
-      .fromEffect(
-        ZIO.effectTotal(channel.newCall(method, options))
-      )
+      .fromEffect(channel.newCall(method, options))
       .flatMap(serverStreamingCall(_, headers, req))
 
   private def serverStreamingCall[R, Req, Res](
@@ -89,8 +82,8 @@ object ClientCalls {
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
   ): ZIO[R with R0, Status, Res] =
-    ZIO
-      .effectTotal(channel.newCall(method, options))
+    channel
+      .newCall(method, options)
       .flatMap(
         clientStreamingCall(
           _,
@@ -125,7 +118,7 @@ object ClientCalls {
   ): ZStream[R with R0, Status, Res] =
     Stream
       .fromEffect(
-        ZIO.effectTotal(channel.newCall(method, options))
+        channel.newCall(method, options)
       )
       .flatMap(bidiCall(_, headers, req))
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/ClientCallsSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/ClientCallsSpec.scala
@@ -1,0 +1,45 @@
+package scalapb.zio_grpc
+
+import io.grpc.{CallOptions, ManagedChannelBuilder}
+import scalapb.zio_grpc.TestUtils._
+import scalapb.zio_grpc.client.ClientCalls
+import scalapb.zio_grpc.testservice._
+import zio.Schedule
+import zio.test.Assertion._
+import zio.test._
+
+object ClientCallsSpec extends DefaultRunnableSpec {
+
+  def unarySuite =
+    suite("unaryCall")(
+      testM("should not fail with 'INTERNAL: already started' on retry") {
+        for {
+          meta <- SafeMetadata.make
+          res  <- ClientCalls
+                    .unaryCall(
+                      // This test does not require working server
+                      new ZChannel(
+                        ManagedChannelBuilder
+                          .forAddress("localhost", 0)
+                          .usePlaintext()
+                          .build(),
+                        Nil
+                      ),
+                      scalapb.zio_grpc.testservice.TestServiceGrpc.METHOD_UNARY,
+                      CallOptions.DEFAULT,
+                      meta,
+                      Request(Request.Scenario.DELAY, in = 12)
+                    )
+                    .retry(Schedule.recurs(2))
+                    .run
+
+        } yield
+        // There was a bug, when call.start was invoked multiple times, so this test was failing
+        // with 'already started' instead of 'io exception'
+        assert(res)(fails(hasDescription("io exception")))
+      }
+    )
+
+  def spec =
+    suite("ClientCallsSpec")(unarySuite)
+}


### PR DESCRIPTION
Hello!
In previous version of zio-grpc, invocation of `channel.newCall` was not lifted into effect:
```
def unary(request: Request): ZIO[...] = 
    scalapb.zio_grpc.client.ClientCalls.unaryCall(
        channel.newCall(...), scalapb.zio_grpc.testservice.TestServiceGrpc.METHOD_UNARY, options,
        headers,
        request
      )}
```
and stateful instance of call was captured on repetitive usage of effect, e.g.:
```
unary(req).retry(...)
```
which causes problems.


Currently, invocation of `unaryCall` is guarded by some steps like `headers.zip(options).flatMap { case (headers, options) =>`  
and that implicitly lifts it into effect, so the problem does not appear.

On another hand, `ClientCalls.unaryCall` is still public and it would be good to make it safer (by explicit wrapping call instantiation)

Do you think is it worth?

