### PR TITLE
Fix server streaming

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,10 +53,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   )
   .jsSettings(
     libraryDependencies ++= Seq(
-      "com.thesamet.scalapb.grpcweb" %%% "scalapb-grpcweb" % "0.4.2",
+      "com.thesamet.scalapb.grpcweb" %%% "scalapb-grpcweb" % "0.4.3",
       "io.github.cquiroz"            %%% "scala-java-time" % "2.1.0" % "test"
     ),
-    npmDependencies in Compile += "grpc-web" -> "1.0.7"
+    npmDependencies in Compile += "grpc-web" -> "1.2.1"
   )
 
 lazy val codeGen = project


### PR DESCRIPTION
Hello!

I've faced the issue with server streaming not works at scala.js with zio-grpc. 

It requires scalapb-grpcweb https://github.com/scalapb/scalapb-grpcweb/pull/77, which adds native grpc-web serverStreaming stub.

So, scalapb-grcweb updated version here is assuming future version with these changes.