### PR TITLE
Re-add 2.13 support for codegen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val codeGen = project
   .enablePlugins(BuildInfoPlugin)
   .settings(stdSettings)
   .settings(
-    scalaVersion := Scala212,
+    crossScalaVersions := Seq(Scala212, Scala213),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "scalapb.zio_grpc",
     name := "zio-grpc-codegen",


### PR DESCRIPTION
See title.

This will enable use of `codegen` for `scala_proto_library` in a bazel codebase (not sbt) using `rules_scala` that's based on scala 2.13.

Related to: https://github.com/scalapb/zio-grpc/issues/213