### PR TITLE
CallDriver exitToStatus prioritizes failures over interrupts

### DIFF
--- a/core/jvm/src/main/scala/scalapb/zio_grpc/server/CallDriver.scala
+++ b/core/jvm/src/main/scala/scalapb/zio_grpc/server/CallDriver.scala
@@ -25,7 +25,7 @@ object CallDriver {
   def exitToStatus(ex: Exit[Status, Unit]): Status =
     ex.fold(
       failed = { cause =>
-        if (cause.interrupted) Status.CANCELLED
+        if (cause.interruptedOnly) Status.CANCELLED
         else cause.failureOption.getOrElse(Status.INTERNAL)
       },
       completed = _ => Status.OK

--- a/e2e/src/test/scala/scalapb/zio_grpc/CallDriverSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/CallDriverSpec.scala
@@ -1,0 +1,28 @@
+package scalapb.zio_grpc
+
+import io.grpc.Status
+import scalapb.zio_grpc.TestUtils._
+import scalapb.zio_grpc.server.CallDriver
+import zio._
+import zio.duration._
+import zio.test.{DefaultRunnableSpec, _}
+
+object CallDriverSpec extends DefaultRunnableSpec {
+
+  def spec = suite("CallDriverSpec")(
+    testM("exitToStatus prioritizes failures over interrupts") {
+      val effectWithInterruptAndFailure = ZIO
+        .foreachParN_(128)(List.range(0, 16))(i =>
+          for {
+            delay <- random.nextIntBetween(100, 200)
+            _     <- environment.live(clock.sleep(delay.milliseconds))
+            _     <- ZIO.fail(Status.INVALID_ARGUMENT.withDescription(s"i=$i"))
+          } yield ()
+        )
+      assertM(effectWithInterruptAndFailure.run map CallDriver.exitToStatus)(
+        hasStatusCode(Status.INVALID_ARGUMENT)
+      )
+    }
+  )
+
+}


### PR DESCRIPTION
Fixes https://github.com/scalapb/zio-grpc/issues/224