### PR TITLE
Remove ZService.withMetadata because it cannot be used safely

### DIFF
--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -306,7 +306,6 @@ class ZioFilePrinter(
               "// Returns a copy of the service with new default metadata",
               s"def withMetadataM[C](headersEffect: zio.ZIO[C, $Status, $SafeMetadata]): ZService[R, C]",
               s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R, Context]",
-              s"def withMetadata(headers: $SafeMetadata): ZService[R, Any] = withMetadataM(zio.ZIO.succeed(headers))"
             )
         )
         .add("}")

--- a/examples/helloworld/src/main/scala/zio_grpc/examples/helloworld/HelloWorldClientMetadata.scala
+++ b/examples/helloworld/src/main/scala/zio_grpc/examples/helloworld/HelloWorldClientMetadata.scala
@@ -86,12 +86,6 @@ object HelloWorldClientMetadata extends zio.App {
             .withMetadataM(userToMetadata(User("hello")))
             .sayHello(HelloRequest("World"))
         _ <- putStrLn(r1.message)
-
-        // Pass prebuilt metadata:
-        md <- SafeMetadata.make
-        _ <- md.put(UserKey, "foo")
-        r1 <- client.withMetadata(md).sayHello(HelloRequest("World"))
-        _ <- putStrLn(r1.message)
       } yield ()
     }
 


### PR DESCRIPTION
Leave withMetadataM as the safe alternative. See #270.