### PR TITLE
Less restrictive type for ServiceList.addManaged

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/ServiceList.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/ServiceList.scala
@@ -19,7 +19,7 @@ sealed class ServiceList[-RR] private[scalapb] (val bindAll: ZManaged[RR, Throwa
   )(implicit b: ZBindableService[R1, S1]): ServiceList[R1 with R2] =
     addManaged[R1, R2, S1](s1.toManaged_)
 
-  def addManaged[R1 <: RR, R2 <: RR, S1](s1: ZManaged[R1 with R2, Throwable, S1])(implicit
+  def addManaged[R1 <: RR, R2 <: RR, S1](s1: ZManaged[R2, Throwable, S1])(implicit
       bs: ZBindableService[R1, S1]
   ): ServiceList[RR with R1 with R2] =
     new ServiceList(for {

--- a/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
@@ -1,12 +1,11 @@
 package scalapb.zio_grpc
 
 import scalapb.zio_grpc.testservice.ZioTestservice.ZTestService
-import zio.Has
+import zio.{Has, Managed, ZIO}
 import zio.clock.Clock
 import zio.console.Console
 import io.grpc.Status
 import scalapb.zio_grpc.testservice.{Request, Response}
-import zio.ZIO
 import zio.stream.ZStream
 import io.grpc.ServerBuilder
 import zio.test._
@@ -67,6 +66,7 @@ object BindableServiceSpec extends DefaultRunnableSpec {
   val z6 = ServiceList.addM(ZIO.succeed(S6))
   val z7 = ServiceList.addM(ZIO.succeed(S7))
   val z8 = ServiceList.access[S1.type]
+  val z9 = ServiceList.addManaged(Managed.succeed(S4))
 
   def spec = suite("BindableServiceSpec")()
 }


### PR DESCRIPTION
It seems `s1: ZManaged[R1 with R2, Throwable, S1]` doesn't need to depend on `R1`. Context: I got compile errors for `ServiceList.addManaged` but not `ServiceList.add` while using the same implementation.