### PR TITLE
Add SafeMetadata.wrapM

### DIFF
--- a/core/src/main/scala/scalapb/zio_grpc/SafeMetadata.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/SafeMetadata.scala
@@ -20,7 +20,10 @@ final class SafeMetadata private (
 
   /** Creates an effect from a total side-effecting function of metadata */
   def wrap[A](f: Metadata => A): UIO[A] =
-    sem.withPermit(ZIO.effectTotal(f(metadata)))
+    wrapM(metadata => ZIO.effectTotal(f(metadata)))
+
+  def wrapM[R, E, A](f: Metadata => ZIO[R, E, A]): ZIO[R, E, A] =
+    sem.withPermit(f(metadata))
 }
 
 object SafeMetadata {


### PR DESCRIPTION
Does this make sense? Context: I'm trying this out with [zio-telemetry](https://github.com/zio/zio-telemetry), in particular this function [Tracing.inject](https://github.com/zio/zio-telemetry/blob/master/opentelemetry/src/main/scala/zio/telemetry/opentelemetry/Tracing.scala#L160) where `C` would be `Metadata` and the return type is an ZIO effect.