### PR TITLE
Send headers only if effect runs successfully

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/CallDriver.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/CallDriver.scala
@@ -62,7 +62,6 @@ object CallDriver {
       run = (
         call.request(2) *>
           completed.await *>
-          call.sendHeaders(new Metadata) *>
           request.await >>= writeResponse
       ).onExit(ex => call.close(CallDriver.exitToStatus(ex), new Metadata).ignore)
         .ignore

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -61,7 +61,11 @@ object ZServerCallHandler {
   ): ServerCallHandler[Req, Res] =
     unaryInput(
       runtime,
-      (req, requestContext, call) => impl(req).provide(Has(requestContext)).flatMap[Any, Status, Unit](call.sendMessage)
+      (req, requestContext, call) =>
+        impl(req)
+          .provide(Has(requestContext))
+          .zipLeft(call.sendHeaders(new Metadata))
+          .flatMap[Any, Status, Unit](call.sendMessage)
     )
 
   def serverStreamingCallHandler[Req, Res](
@@ -71,7 +75,7 @@ object ZServerCallHandler {
     unaryInput(
       runtime,
       (req: Req, metadata: RequestContext, call: ZServerCall[Res]) =>
-        impl(req).provide(Has(metadata)).foreach(call.sendMessage)
+        call.sendHeaders(new Metadata) *> impl(req).provide(Has(metadata)).foreach(call.sendMessage)
     )
 
   def clientStreamingCallHandler[Req, Res](

--- a/e2e/src/main/protobuf/testservice.proto
+++ b/e2e/src/main/protobuf/testservice.proto
@@ -9,6 +9,7 @@ message Request {
         ERROR_AFTER = 2; // for server streaming, error after two responses
         DELAY = 3; // do not return a response. for testing cancellations
         DIE = 4; // fail
+        UNAVAILABLE = 5; // fail with UNAVAILABLE, to test client retries
     }
     Scenario scenario = 1;
     int32 in = 2;

--- a/e2e/src/test/resources/service_config.json
+++ b/e2e/src/test/resources/service_config.json
@@ -1,0 +1,22 @@
+{
+  "methodConfig": [
+    {
+      "name": [
+        {
+          "service": "scalapb.zio_grpc.TestService",
+          "method": "Unary"
+        }
+      ],
+
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.1s",
+        "maxBackoff": "30s",
+        "backoffMultiplier": 1,
+        "retryableStatusCodes": [
+          "UNAVAILABLE"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Here's a shot at https://github.com/scalapb/zio-grpc/issues/298
I verified empirically with a java netty client that it works as expected