### PR TITLE
Terminate client response stream when server response stream terminates

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -138,6 +138,6 @@ object ClientCalls {
           )
         val sendRequestStream = (init ++ req.tap(call.sendMessage) ++ Stream
           .fromZIO(call.halfClose())).drain
-        sendRequestStream.merge(listener.stream)
+        sendRequestStream.merge(listener.stream, ZStream.TerminationStrategy.Right)
       }
 }


### PR DESCRIPTION
I propose to change the client behavior for bidi calls so that the response stream will terminate when the server response terminates, independent of the client request stream terminating. I think it makes sense because:

1. Client may be waiting for response stream to terminate before terminating the request stream. In my case it's because I'm using the request stream to handle back pressure, so the client sends "pull" messages until server terminates. Since the response stream does not terminate until request stream terminates, it deadlocks.

2. I don't see a scenario where it makes sense continue sending messages from client to server after the server terminated the response stream.

Does that make sense? Is there a use case I'm not considering where the current behavior is required?   