### PR TITLE
fix: conversion to milliseconds

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/Server.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/Server.scala
@@ -7,6 +7,10 @@ import java.util.concurrent.TimeUnit
 
 object Server {
   trait Service {
+    def awaitTermination: Task[Unit]
+
+    def awaitTermination(duratio: Duration): Task[Boolean]
+
     def port: Task[Int]
 
     def shutdown: Task[Unit]
@@ -17,14 +21,10 @@ object Server {
   }
 
   private[zio_grpc] class ServiceImpl(underlying: io.grpc.Server) extends Service {
-    private def awaitTermination(duration: Option[Duration]): Task[Unit] =
-      ZIO.attempt(duration match {
-        case None           =>
-          underlying.awaitTermination()
-        case Some(duration) =>
-          val timeout = duration.toMillis()
-          val _       = underlying.awaitTermination(timeout, TimeUnit.MILLISECONDS)
-      })
+    val awaitTermination: Task[Unit] = ZIO.attempt(underlying.awaitTermination())
+
+    def awaitTermination(duration: Duration): Task[Boolean] =
+      ZIO.attempt(underlying.awaitTermination(duration.toMillis(), TimeUnit.MILLISECONDS))
 
     def port: Task[Int] = ZIO.attempt(underlying.getPort())
 
@@ -35,10 +35,7 @@ object Server {
     def shutdownNow: Task[Unit] = ZIO.attempt(underlying.shutdownNow()).unit
 
     def toManaged: ZIO[Scope, Throwable, Service] =
-      start.as(this).withFinalizer(_ => this.shutdown.ignore *> this.awaitTermination(None).ignore)
-
-    def toManaged(awaitTermination: Duration): ZIO[Scope, Throwable, Service] =
-      start.as(this).withFinalizer(_ => this.shutdown.ignore *> this.awaitTermination(Some(awaitTermination)).ignore)
+      start.as(this).withFinalizer(_ => this.shutdown.ignore)
   }
 
   @deprecated("Use ManagedServer.fromBuilder", "0.4.0")

--- a/core/src/main/scalajvm/scalapb/zio_grpc/Server.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/Server.scala
@@ -4,7 +4,6 @@ import zio.{Duration, Scope, Tag, Task, URIO, ZIO, ZLayer}
 import io.grpc.ServerBuilder
 import io.grpc.ServerServiceDefinition
 import java.util.concurrent.TimeUnit
-import java.time.temporal.ChronoUnit
 
 object Server {
   trait Service {
@@ -23,7 +22,8 @@ object Server {
         case None           =>
           underlying.awaitTermination()
         case Some(duration) =>
-          val _ = underlying.awaitTermination(duration.get(ChronoUnit.MILLIS), TimeUnit.MILLISECONDS)
+          val timeout = duration.toMillis()
+          val _       = underlying.awaitTermination(timeout, TimeUnit.MILLISECONDS)
       })
 
     def port: Task[Int] = ZIO.attempt(underlying.getPort())

--- a/e2e/src/test/scala/scalapb/zio_grpc/ServerSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/ServerSpec.scala
@@ -1,0 +1,61 @@
+package scalapb.zio_grpc
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+import java.util.concurrent.TimeUnit
+import java.time.Duration
+
+object ServerSpec extends ZIOSpecDefault {
+  val spec =
+    suite("Server")(
+      test("Awaits termination") {
+        for {
+          waitedRef <- Ref.make(false)
+          server     = new io.grpc.Server {
+                         def awaitTermination(): Unit = {
+                           val _ = Unsafe.unsafe { implicit unsafe =>
+                             Runtime.default.unsafe.run(waitedRef.set(true)).getOrThrowFiberFailure()
+                           }
+                         }
+
+                         def start(): io.grpc.Server                                  = ???
+                         def shutdown(): io.grpc.Server                               = ???
+                         def shutdownNow(): io.grpc.Server                            = ???
+                         def isShutdown(): Boolean                                    = ???
+                         def isTerminated(): Boolean                                  = ???
+                         def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = ???
+                       }
+          pbServer   = new Server.ServiceImpl(server)
+          _         <- pbServer.awaitTermination
+          waited    <- waitedRef.get
+        } yield assert(waited)(isTrue)
+      },
+      test("Awaits termination with timeout") {
+        for {
+          waitedRef <- Ref.make[TestResult](assert(false)(isTrue))
+          runtime   <- ZIO.runtime[Any]
+          server     = new io.grpc.Server {
+                         def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+                           val assertion1 = assert(timeout)(equalTo(2500L))
+                           val assertion2 = assert(unit)(equalTo(TimeUnit.MILLISECONDS))
+                           Unsafe.unsafe { implicit unsafe =>
+                             Runtime.default.unsafe.run(waitedRef.set(assertion1 && assertion2)).getOrThrowFiberFailure()
+                           }
+                           true
+                         }
+
+                         def start(): io.grpc.Server       = ???
+                         def shutdown(): io.grpc.Server    = ???
+                         def shutdownNow(): io.grpc.Server = ???
+                         def isShutdown(): Boolean         = ???
+                         def isTerminated(): Boolean       = ???
+                         def awaitTermination(): Unit      = ???
+                       }
+          pbServer   = new Server.ServiceImpl(server)
+          _         <- pbServer.awaitTermination(Duration.ofSeconds(2, 500000000L))
+          assertion <- waitedRef.get
+        } yield assertion
+      }
+    )
+}

--- a/e2e/src/test/scala/scalapb/zio_grpc/ServerSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/ServerSpec.scala
@@ -9,7 +9,7 @@ import java.time.Duration
 object ServerSpec extends ZIOSpecDefault {
   val spec =
     suite("Server")(
-      test("Awaits termination") {
+      test("awaitsTermination delegates to underlying implementation (without timeout)") {
         for {
           waitedRef <- Ref.make(false)
           server     = new io.grpc.Server {
@@ -31,7 +31,7 @@ object ServerSpec extends ZIOSpecDefault {
           waited    <- waitedRef.get
         } yield assert(waited)(isTrue)
       },
-      test("Awaits termination with timeout") {
+      test("awaitsTermination delegates to underlying implementation (with timeout)") {
         for {
           waitedRef <- Ref.make[TestResult](assert(false)(isTrue))
           runtime   <- ZIO.runtime[Any]


### PR DESCRIPTION
After trying this out it turns out `.get` only accepts `SECONDS` or `NANOS`