### PR TITLE
feat: Add client support for response metadata

### DIFF
--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -341,6 +341,10 @@ class ZioFilePrinter(
             printClientTransform
           )
             .add(
+              "// Returns a client that gives access to headers and trailers",
+              s"def withMetadata: ${clientWithMetadataServiceName.name}.ZService[R1, Context1] = self.withMetadata.transform[R1, Context1](f)"
+            )
+            .add(
               "// Returns a copy of the service with new default metadata",
               s"def mapCallOptionsM(cf: $CallOptions => zio.IO[$Status, $CallOptions]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.mapCallOptionsM(cf), f)",
               s"def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.withMetadataM(headersEffect), f)",
@@ -500,6 +504,10 @@ class ZioFilePrinter(
           )
             .add("")
             .add(
+              "// Returns a client that gives access to headers and trailers",
+              s"def withMetadata: ${clientWithMetadataServiceName.name}.ZService[R, Context]"
+            )
+            .add(
               "// Returns a copy of the service with new default metadata",
               s"def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R, Context]",
               s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R, Context]"
@@ -522,6 +530,10 @@ class ZioFilePrinter(
           _.print(service.getMethods().asScala.toVector)(
             printClientImpl(envType = "R with Context")
           )
+            .add(
+              "// Returns a client that gives access to headers and trailers",
+              s"def withMetadata: ${clientWithMetadataServiceName.name}.ZService[R, Context] = underlying"
+            )
             .add(
               s"def mapCallOptionsM(f: $CallOptions => zio.IO[$Status, $CallOptions]): ZService[R, Context] = new ServiceStub(underlying.mapCallOptionsM(f))",
               s"override def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R, Context] = new ServiceStub(underlying.withMetadataM(headersEffect))",

--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -17,6 +17,7 @@ import protocgen.CodeGenRequest
 import scalapb.compiler.NameUtils
 
 import scala.jdk.CollectionConverters._
+import scala.util.chaining._
 
 object ZioCodeGenerator extends CodeGenApp {
   override def registerExtensions(registry: ExtensionRegistry): Unit =
@@ -103,8 +104,9 @@ class ZioFilePrinter(
     private val traitName  = OuterObject / service.name
     private val ztraitName = OuterObject / ("Z" + service.name)
 
-    private val clientServiceName  = OuterObject / (service.name + "Client")
-    private val accessorsClassName = OuterObject / (service.name + "Accessors")
+    private val clientServiceName             = OuterObject / (service.name + "Client")
+    private val clientWithMetadataServiceName = OuterObject / (service.name + "ClientWithMetadata")
+    private val accessorsClassName            = OuterObject / (service.name + "Accessors")
 
     def methodInType(method: MethodDescriptor, inEnvType: String): String = {
       val scalaInType = method.inputType.scalaType
@@ -161,6 +163,28 @@ class ZioFilePrinter(
       })
     }
 
+    def clientWithMetadataMethodSignature(
+        method: MethodDescriptor,
+        inEnvType: String,
+        outEnvType: String
+    ): String = {
+      val reqType       = methodInType(method, inEnvType)
+      val scalaOutType  = method.outputType.scalaType
+      val ioOutType     = s"scalapb.zio_grpc.ResponseContext[$scalaOutType]"
+      val streamOutType = s"scalapb.zio_grpc.ResponseFrame[$scalaOutType]"
+
+      s"def ${method.name}" + (method.streamType match {
+        case StreamType.Unary           =>
+          s"(request: $reqType): ${io(ioOutType, outEnvType)}"
+        case StreamType.ClientStreaming =>
+          s"[${inEnvType}](request: $reqType): ${io(ioOutType, outEnvType + " with " + inEnvType)}"
+        case StreamType.ServerStreaming =>
+          s"(request: $reqType): ${stream(streamOutType, outEnvType)}"
+        case StreamType.Bidirectional   =>
+          s"[${inEnvType}](request: $reqType): ${stream(streamOutType, outEnvType + " with " + inEnvType)}"
+      })
+    }
+
     def printMethodSignature(
         inEnvType: String,
         outEnvType: String
@@ -191,6 +215,21 @@ class ZioFilePrinter(
         )
       )
 
+    def printClientWithMetadataMethodSignature(
+        inEnvType: String,
+        outEnvType: String
+    )(
+        fp: FunctionalPrinter,
+        method: MethodDescriptor
+    ): FunctionalPrinter =
+      fp.add(
+        clientWithMetadataMethodSignature(
+          method,
+          inEnvType,
+          outEnvType
+        )
+      )
+
     def printServerTransform(
         fp: FunctionalPrinter,
         method: MethodDescriptor
@@ -206,6 +245,30 @@ class ZioFilePrinter(
         methodSignature(
           method,
           inEnvType = "Any",
+          outEnvType = "R1 with Context1"
+        ) + " = " + newImpl
+      )
+    }
+
+    def printClientWithMetadataTransform(
+        fp: FunctionalPrinter,
+        method: MethodDescriptor
+    ): FunctionalPrinter = {
+      val delegate = s"self.${method.name}"
+      val newImpl  = method.streamType match {
+        case StreamType.Unary           =>
+          s"f.effect($delegate(request))"
+        case StreamType.ServerStreaming =>
+          s"f.stream($delegate(request))"
+        case StreamType.ClientStreaming =>
+          s"""zio.ZIO.fail($Status.INTERNAL.withDescription("Transforming client-side client-streaming calls is not supported"))"""
+        case StreamType.Bidirectional   =>
+          s"""zio.stream.ZStream.fail($Status.INTERNAL.withDescription("Transforming client-side bidi calls is not supported"))"""
+      }
+      fp.add(
+        clientWithMetadataMethodSignature(
+          method,
+          inEnvType = "RR",
           outEnvType = "R1 with Context1"
         ) + " = " + newImpl
       )
@@ -248,6 +311,25 @@ class ZioFilePrinter(
         ).add("}")
       ).add("}")
 
+    def clientWithMetadataTranformableService(fp: FunctionalPrinter): FunctionalPrinter =
+      fp.add(
+        s"implicit val transformableService: scalapb.zio_grpc.TransformableService[ZService] = new scalapb.zio_grpc.TransformableService[ZService] {"
+      ).indented(
+        _.add(
+          s"def transform[R, Context, R1, Context1](self: ZService[R, Context], f: scalapb.zio_grpc.ZTransform[R with Context, $Status, R1 with Context1]): ZService[R1, Context1] = new ZService[R1, Context1] {"
+        ).indented(
+          _.print(service.getMethods().asScala.toVector)(
+            printClientWithMetadataTransform
+          )
+            .add(
+              "// Returns a copy of the service with new default metadata",
+              s"def mapCallOptionsM(cf: $CallOptions => zio.IO[$Status, $CallOptions]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.mapCallOptionsM(cf), f)",
+              s"def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.withMetadataM(headersEffect), f)",
+              s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.withCallOptionsM(callOptions), f)"
+            )
+        ).add("}")
+      ).add("}")
+
     def clientTranformableService(fp: FunctionalPrinter): FunctionalPrinter =
       fp.add(
         s"implicit val transformableService: scalapb.zio_grpc.TransformableService[ZService] = new scalapb.zio_grpc.TransformableService[ZService] {"
@@ -261,7 +343,7 @@ class ZioFilePrinter(
             .add(
               "// Returns a copy of the service with new default metadata",
               s"def mapCallOptionsM(cf: $CallOptions => zio.IO[$Status, $CallOptions]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.mapCallOptionsM(cf), f)",
-              s"def withMetadataM[C](headersEffect: zio.ZIO[C, $Status, $SafeMetadata]): ZService[R1, C] = ??? // transform[R, Context, R1, C](self.withMetadataM(headersEffect), f)",
+              s"def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.withMetadataM(headersEffect), f)",
               s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R1, Context1] = transform[R, Context, R1, Context1](self.withCallOptionsM(callOptions), f)"
             )
         ).add("}")
@@ -316,10 +398,6 @@ class ZioFilePrinter(
         )
         .add("}")
         .add("")
-        .add(
-          s"type ${clientServiceName.name} = _root_.zio.Has[${clientServiceName.name}.Service]"
-        )
-        .add("")
         .add("// accessor methods")
         .add(
           s"class ${accessorsClassName.name}[Context: zio.Tag](callOptions: zio.IO[$Status, $CallOptions]) extends scalapb.zio_grpc.CallOptionsMethods[${accessorsClassName.name}[Context]] {"
@@ -332,6 +410,79 @@ class ZioFilePrinter(
             )
         )
         .add("}")
+        .add("")
+        .pipe(genClient)
+        .pipe(genClientWithMetadata)
+
+    def genClientWithMetadata(fp: FunctionalPrinter): FunctionalPrinter =
+      fp
+        .add(
+          s"type ${clientWithMetadataServiceName.name} = _root_.zio.Has[${clientWithMetadataServiceName.name}.Service]"
+        )
+        .add("")
+        .add(
+          s"object ${clientWithMetadataServiceName.name} extends ${accessorsClassName.name}[Any](zio.ZIO.succeed($CallOptions.DEFAULT)) {"
+        )
+        .indent
+        .add(
+          s"trait ZService[R, Context] extends scalapb.zio_grpc.CallOptionsMethods[ZService[R, Context]] {"
+        )
+        .indented(
+          _.print(service.getMethods().asScala.toVector)(
+            printClientWithMetadataMethodSignature(
+              inEnvType = "R0",
+              outEnvType = "R with Context"
+            )
+          )
+            .add("")
+            .add(
+              "// Returns a copy of the service with new default metadata",
+              s"def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R, Context]",
+              s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R, Context]"
+            )
+        )
+        .add("}")
+        .add(s"type Service = ZService[Any, Any]")
+        .add(s"type Accessors[Context] = ${accessorsClassName.fullName}[Context]")
+        .call(clientWithMetadataTranformableService)
+        .add(
+          s"implicit def ops[R, C](service: ZService[R, C]): scalapb.zio_grpc.TransformableService.TransformableServiceOps[ZService, R, C] = new scalapb.zio_grpc.TransformableService.TransformableServiceOps[ZService, R, C](service)"
+        )
+        .add("")
+        .add("")
+        .add(
+          s"private[this] class ServiceStub[R, Context](channel: $ZChannel[R], options: zio.IO[$Status, $CallOptions], headers: zio.ZIO[Context, $Status, $SafeMetadata])"
+        )
+        .add(s"    extends ${clientWithMetadataServiceName.name}.ZService[R, Context] {")
+        .indented(
+          _.print(service.getMethods().asScala.toVector)(
+            printClientWithMetadataImpl(envType = "R with Context")
+          )
+            .add(
+              s"def mapCallOptionsM(f: $CallOptions => zio.IO[$Status, $CallOptions]): ZService[R, Context] = new ServiceStub(channel, options.flatMap(f), headers)",
+              s"override def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R, Context] = new ServiceStub(channel, options, headersEffect)",
+              s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R, Context] = new ServiceStub(channel, callOptions, headers)"
+            )
+        )
+        .add("}")
+        .add("")
+        .add(
+          s"def managed[R, Context](managedChannel: $ZManagedChannel[R], options: zio.IO[$Status, $CallOptions] = zio.ZIO.succeed($CallOptions.DEFAULT), headers: zio.ZIO[Context, $Status, $SafeMetadata]=$SafeMetadata.make): zio.Managed[Throwable, ${clientWithMetadataServiceName.name}.ZService[R, Context]] = managedChannel.map {"
+        )
+        .add("  channel => new ServiceStub[R, Context](channel, options, headers)")
+        .add("}")
+        .add("")
+        .add(
+          s"def live[R, Context: zio.Tag](managedChannel: $ZManagedChannel[R], options: zio.IO[$Status, $CallOptions]=zio.ZIO.succeed($CallOptions.DEFAULT), headers: zio.ZIO[Context, $Status, $SafeMetadata] = $SafeMetadata.make): zio.ZLayer[R, Throwable, zio.Has[${clientWithMetadataServiceName.name}.ZService[Any, Context]]] = zio.ZLayer.fromFunctionManaged((r: R) => managed[Any, Context](managedChannel.map(_.provide(r)), options, headers))"
+        )
+        .outdent
+        .add("}")
+
+    def genClient(fp: FunctionalPrinter): FunctionalPrinter =
+      fp
+        .add(
+          s"type ${clientServiceName.name} = _root_.zio.Has[${clientServiceName.name}.Service]"
+        )
         .add("")
         .add(
           s"object ${clientServiceName.name} extends ${accessorsClassName.name}[Any](zio.ZIO.succeed($CallOptions.DEFAULT)) {"
@@ -350,7 +501,7 @@ class ZioFilePrinter(
             .add("")
             .add(
               "// Returns a copy of the service with new default metadata",
-              s"def withMetadataM[C](headersEffect: zio.ZIO[C, $Status, $SafeMetadata]): ZService[R, C]",
+              s"def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R, Context]",
               s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R, Context]"
             )
         )
@@ -364,7 +515,7 @@ class ZioFilePrinter(
         .add("")
         .add("")
         .add(
-          s"private[this] class ServiceStub[R, Context](channel: $ZChannel[R], options: zio.IO[$Status, $CallOptions], headers: zio.ZIO[Context, $Status, $SafeMetadata])"
+          s"private[this] class ServiceStub[R, Context](underlying: ${clientWithMetadataServiceName.name}.ZService[R, Context])"
         )
         .add(s"    extends ${clientServiceName.name}.ZService[R, Context] {")
         .indented(
@@ -372,21 +523,19 @@ class ZioFilePrinter(
             printClientImpl(envType = "R with Context")
           )
             .add(
-              s"def mapCallOptionsM(f: $CallOptions => zio.IO[$Status, $CallOptions]): ZService[R, Context] = new ServiceStub(channel, options.flatMap(f), headers)",
-              s"override def withMetadataM[C](headersEffect: zio.ZIO[C, $Status, $SafeMetadata]): ZService[R, C] = new ServiceStub(channel, options, headersEffect)",
-              s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R, Context] = new ServiceStub(channel, callOptions, headers)"
+              s"def mapCallOptionsM(f: $CallOptions => zio.IO[$Status, $CallOptions]): ZService[R, Context] = new ServiceStub(underlying.mapCallOptionsM(f))",
+              s"override def withMetadataM(headersEffect: zio.IO[$Status, $SafeMetadata]): ZService[R, Context] = new ServiceStub(underlying.withMetadataM(headersEffect))",
+              s"def withCallOptionsM(callOptions: zio.IO[$Status, $CallOptions]): ZService[R, Context] = new ServiceStub(underlying.withCallOptionsM(callOptions))"
             )
         )
         .add("}")
         .add("")
         .add(
-          s"def managed[R, Context](managedChannel: $ZManagedChannel[R], options: zio.IO[$Status, $CallOptions] = zio.ZIO.succeed($CallOptions.DEFAULT), headers: zio.ZIO[Context, $Status, $SafeMetadata]=$SafeMetadata.make): zio.Managed[Throwable, ${clientServiceName.name}.ZService[R, Context]] = managedChannel.map {"
+          s"def managed[R, Context](managedChannel: $ZManagedChannel[R], options: zio.IO[$Status, $CallOptions] = zio.ZIO.succeed($CallOptions.DEFAULT), headers: zio.ZIO[Context, $Status, $SafeMetadata]=$SafeMetadata.make): zio.Managed[Throwable, ${clientServiceName.name}.ZService[R, Context]] = ${clientWithMetadataServiceName.name}.managed(managedChannel, options, headers).map(client => new ServiceStub(client))"
         )
-        .add("  channel => new ServiceStub[R, Context](channel, options, headers)")
-        .add("}")
         .add("")
         .add(
-          s"def live[R, Context: zio.Tag](managedChannel: $ZManagedChannel[R], options: zio.IO[$Status, $CallOptions]=zio.ZIO.succeed($CallOptions.DEFAULT), headers: zio.ZIO[Context, $Status, $SafeMetadata] = $SafeMetadata.make): zio.ZLayer[R, Throwable, zio.Has[${clientServiceName.name}.ZService[Any, Context]]] = zio.ZLayer.fromFunctionManaged((r: R) => managed[Any, Context](managedChannel.map(_.provide(r)), options, headers))"
+          s"def live[R, Context: zio.Tag](managedChannel: $ZManagedChannel[R], options: zio.IO[$Status, $CallOptions]=zio.ZIO.succeed($CallOptions.DEFAULT), headers: zio.ZIO[Context, $Status, $SafeMetadata] = $SafeMetadata.make): zio.ZLayer[R, Throwable, zio.Has[${clientServiceName.name}.ZService[Any, Context]]] = ${clientWithMetadataServiceName.name}.live(managedChannel, options, headers).map(clientHas => _root_.zio.Has(new ServiceStub(clientHas.get)))"
         )
         .outdent
         .add("}")
@@ -413,14 +562,14 @@ class ZioFilePrinter(
       fp.add(sigWithoutContext + clientCall)
     }
 
-    def printClientImpl(
+    def printClientWithMetadataImpl(
         envType: String
     )(fp: FunctionalPrinter, method: MethodDescriptor): FunctionalPrinter = {
       val clientCall = method.streamType match {
-        case StreamType.Unary           => s"$ClientCalls.unaryCall"
-        case StreamType.ClientStreaming => s"$ClientCalls.clientStreamingCall"
-        case StreamType.ServerStreaming => s"$ClientCalls.serverStreamingCall"
-        case StreamType.Bidirectional   => s"$ClientCalls.bidiCall"
+        case StreamType.Unary           => s"$ClientCalls.withMetadata.unaryCall"
+        case StreamType.ClientStreaming => s"$ClientCalls.withMetadata.clientStreamingCall"
+        case StreamType.ServerStreaming => s"$ClientCalls.withMetadata.serverStreamingCall"
+        case StreamType.Bidirectional   => s"$ClientCalls.withMetadata.bidiCall"
       }
       val prefix     = method.streamType match {
         case StreamType.Unary           => s"headers.zip(options).flatMap"
@@ -431,7 +580,7 @@ class ZioFilePrinter(
           s"zio.stream.ZStream.fromEffect(headers.zip(options)).flatMap"
       }
       fp.add(
-        clientMethodSignature(
+        clientWithMetadataMethodSignature(
           method,
           inEnvType = "R0",
           outEnvType = envType
@@ -445,6 +594,26 @@ class ZioFilePrinter(
         .outdent
         .add(s")}")
     }
+
+    def printClientImpl(
+        envType: String
+    )(fp: FunctionalPrinter, method: MethodDescriptor): FunctionalPrinter = {
+      val suffix = method.streamType match {
+        case StreamType.Unary | StreamType.ClientStreaming         =>
+          ".map(_.response)"
+        case StreamType.ServerStreaming | StreamType.Bidirectional =>
+          ".collect { case scalapb.zio_grpc.ResponseFrame.Message(message) => message }"
+      }
+
+      fp.add(
+        clientMethodSignature(
+          method,
+          inEnvType = "R0",
+          outEnvType = envType
+        ) + s" = underlying.${method.name}(request)$suffix"
+      )
+    }
+
     def printBindService(
         fp: FunctionalPrinter,
         method: MethodDescriptor

--- a/core/src/main/scala/scalapb/zio_grpc/ResponseContext.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/ResponseContext.scala
@@ -1,0 +1,9 @@
+package scalapb.zio_grpc
+
+import io.grpc.Metadata
+
+final case class ResponseContext[A](
+    headers: Metadata,
+    response: A,
+    trailers: Metadata
+)

--- a/core/src/main/scala/scalapb/zio_grpc/ResponseFrame.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/ResponseFrame.scala
@@ -1,0 +1,12 @@
+package scalapb.zio_grpc
+
+import io.grpc.Metadata
+import io.grpc.Status
+
+sealed abstract class ResponseFrame[+A]
+
+object ResponseFrame {
+  final case class Headers(headers: Metadata)                   extends ResponseFrame[Nothing]
+  final case class Message[A](message: A)                       extends ResponseFrame[A]
+  final case class Trailers(status: Status, trailers: Metadata) extends ResponseFrame[Nothing]
+}

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc.client
 
-import io.grpc.{CallOptions, MethodDescriptor, Status}
+import io.grpc.{CallOptions, Metadata, MethodDescriptor, Status}
 import scalapb.zio_grpc.{SafeMetadata, ZChannel}
 import zio.stream.{Stream, ZStream}
 import zio.{Exit, ZIO}
@@ -27,6 +27,15 @@ object ClientCalls {
       headers: SafeMetadata,
       req: Req
   ): ZIO[R, Status, Res] =
+    unaryCallWithMetadata(channel, method, options, headers, req).map(_._2)
+
+  def unaryCallWithMetadata[R, Req, Res](
+      channel: ZChannel[R],
+      method: MethodDescriptor[Req, Res],
+      options: CallOptions,
+      headers: SafeMetadata,
+      req: Req
+  ): ZIO[R, Status, (Metadata, Res)] =
     channel
       .newCall(method, options)
       .flatMap(unaryCall(_, headers, req))
@@ -35,13 +44,13 @@ object ClientCalls {
       call: ZClientCall[R, Req, Res],
       headers: SafeMetadata,
       req: Req
-  ): ZIO[R, Status, Res] =
+  ): ZIO[R, Status, (Metadata, Res)] =
     ZIO.bracketExit(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
       call.start(listener, headers) *>
         call.request(1) *>
         call.sendMessage(req) *>
         call.halfClose() *>
-        listener.getValue.map(_._2)
+        listener.getValue
     }
 
   def serverStreamingCall[R, Req, Res](
@@ -50,7 +59,17 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): ZStream[R, Status, Res] =
+  ): ZStream[R, Status, Res]                   =
+    serverStreamingCallWithMetadata(channel, method, options, headers, req)
+      .collect { case Right(x) => x }
+
+  def serverStreamingCallWithMetadata[R, Req, Res](
+      channel: ZChannel[R],
+      method: MethodDescriptor[Req, Res],
+      options: CallOptions,
+      headers: SafeMetadata,
+      req: Req
+  ): ZStream[R, Status, Either[Metadata, Res]] =
     Stream
       .fromEffect(channel.newCall(method, options))
       .flatMap(serverStreamingCall(_, headers, req))
@@ -59,7 +78,7 @@ object ClientCalls {
       call: ZClientCall[R, Req, Res],
       headers: SafeMetadata,
       req: Req
-  ): ZStream[R, Status, Res] =
+  ): ZStream[R, Status, Either[Metadata, Res]] =
     Stream
       .bracketExit(
         StreamingClientCallListener.make[R, Res](call)
@@ -82,6 +101,15 @@ object ClientCalls {
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
   ): ZIO[R with R0, Status, Res] =
+    clientStreamingCallWithMetadata(channel, method, options, headers, req).map(_._2)
+
+  def clientStreamingCallWithMetadata[R, R0, Req, Res](
+      channel: ZChannel[R],
+      method: MethodDescriptor[Req, Res],
+      options: CallOptions,
+      headers: SafeMetadata,
+      req: ZStream[R0, Status, Req]
+  ): ZIO[R with R0, Status, (Metadata, Res)] =
     channel
       .newCall(method, options)
       .flatMap(
@@ -96,7 +124,7 @@ object ClientCalls {
       call: ZClientCall[R, Req, Res],
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
-  ): ZIO[R with R0, Status, Res] =
+  ): ZIO[R with R0, Status, (Metadata, Res)] =
     ZIO.bracketExit(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
       val callStream   = req.tap(call.sendMessage).drain ++ ZStream.fromEffect(call.halfClose()).drain
       val resultStream = ZStream.fromEffect(listener.getValue)
@@ -106,7 +134,7 @@ object ClientCalls {
         callStream
           .merge(resultStream)
           .runCollect
-          .map(res => res.last._2)
+          .map(res => res.last)
     }
 
   def bidiCall[R, R0, Req, Res](
@@ -115,7 +143,17 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
-  ): ZStream[R with R0, Status, Res] =
+  ): ZStream[R with R0, Status, Res]                   =
+    bidiCallWithMetadata(channel, method, options, headers, req)
+      .collect { case Right(x) => x }
+
+  def bidiCallWithMetadata[R, R0, Req, Res](
+      channel: ZChannel[R],
+      method: MethodDescriptor[Req, Res],
+      options: CallOptions,
+      headers: SafeMetadata,
+      req: ZStream[R0, Status, Req]
+  ): ZStream[R with R0, Status, Either[Metadata, Res]] =
     Stream
       .fromEffect(
         channel.newCall(method, options)
@@ -126,7 +164,7 @@ object ClientCalls {
       call: ZClientCall[R, Req, Res],
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
-  ): ZStream[R with R0, Status, Res] =
+  ): ZStream[R with R0, Status, Either[Metadata, Res]] =
     Stream
       .bracketExit(
         StreamingClientCallListener.make[R, Res](call)

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -1,11 +1,138 @@
 package scalapb.zio_grpc.client
 
-import io.grpc.{CallOptions, Metadata, MethodDescriptor, Status}
-import scalapb.zio_grpc.{SafeMetadata, ZChannel}
+import io.grpc.{CallOptions, MethodDescriptor, Status}
+import scalapb.zio_grpc.{ResponseContext, ResponseFrame, SafeMetadata, ZChannel}
 import zio.stream.{Stream, ZStream}
 import zio.{Exit, ZIO}
 
 object ClientCalls {
+  object withMetadata {
+
+    private def unaryCall[R, Req, Res](
+        call: ZClientCall[R, Req, Res],
+        headers: SafeMetadata,
+        req: Req
+    ): ZIO[R, Status, ResponseContext[Res]] =
+      ZIO.bracketExit(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
+        call.start(listener, headers) *>
+          call.request(1) *>
+          call.sendMessage(req) *>
+          call.halfClose() *>
+          listener.getValue
+      }
+
+    def unaryCall[R, Req, Res](
+        channel: ZChannel[R],
+        method: MethodDescriptor[Req, Res],
+        options: CallOptions,
+        headers: SafeMetadata,
+        req: Req
+    ): ZIO[R, Status, ResponseContext[Res]] =
+      channel
+        .newCall(method, options)
+        .flatMap(unaryCall(_, headers, req))
+
+    private def serverStreamingCall[R, Req, Res](
+        call: ZClientCall[R, Req, Res],
+        headers: SafeMetadata,
+        req: Req
+    ): ZStream[R, Status, ResponseFrame[Res]] =
+      Stream
+        .bracketExit(
+          StreamingClientCallListener.make[R, Res](call)
+        )(anyExitHandler[R, Req, Res](call))
+        .flatMap { (listener: StreamingClientCallListener[R, Res]) =>
+          Stream
+            .fromEffect(
+              call.start(listener, headers) *>
+                call.request(1) *>
+                call.sendMessage(req) *>
+                call.halfClose()
+            )
+            .drain ++ listener.stream
+        }
+
+    def serverStreamingCall[R, Req, Res](
+        channel: ZChannel[R],
+        method: MethodDescriptor[Req, Res],
+        options: CallOptions,
+        headers: SafeMetadata,
+        req: Req
+    ): ZStream[R, Status, ResponseFrame[Res]] =
+      Stream
+        .fromEffect(channel.newCall(method, options))
+        .flatMap(serverStreamingCall(_, headers, req))
+
+    private def clientStreamingCall[R, R0, Req, Res](
+        call: ZClientCall[R, Req, Res],
+        headers: SafeMetadata,
+        req: ZStream[R0, Status, Req]
+    ): ZIO[R with R0, Status, ResponseContext[Res]] =
+      ZIO.bracketExit(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
+        val callStream   = req.tap(call.sendMessage).drain ++ ZStream.fromEffect(call.halfClose()).drain
+        val resultStream = ZStream.fromEffect(listener.getValue)
+
+        call.start(listener, headers) *>
+          call.request(1) *>
+          callStream
+            .merge(resultStream)
+            .runCollect
+            .map(res => res.last)
+      }
+
+    def clientStreamingCall[R, R0, Req, Res](
+        channel: ZChannel[R],
+        method: MethodDescriptor[Req, Res],
+        options: CallOptions,
+        headers: SafeMetadata,
+        req: ZStream[R0, Status, Req]
+    ): ZIO[R with R0, Status, ResponseContext[Res]] =
+      channel
+        .newCall(method, options)
+        .flatMap(
+          clientStreamingCall(
+            _,
+            headers,
+            req
+          )
+        )
+
+    private def bidiCall[R, R0, Req, Res](
+        call: ZClientCall[R, Req, Res],
+        headers: SafeMetadata,
+        req: ZStream[R0, Status, Req]
+    ): ZStream[R with R0, Status, ResponseFrame[Res]] =
+      Stream
+        .bracketExit(
+          StreamingClientCallListener.make[R, Res](call)
+        )(anyExitHandler(call))
+        .flatMap { (listener: StreamingClientCallListener[R, Res]) =>
+          val init              = Stream
+            .fromEffect(
+              call.start(listener, headers) *>
+                call.request(1)
+            )
+          val finish            = Stream
+            .fromEffect(call.halfClose())
+          val sendRequestStream = (init ++ req.tap(call.sendMessage) ++ finish).drain
+          sendRequestStream.merge(listener.stream, ZStream.TerminationStrategy.Right)
+        }
+
+    def bidiCall[R, R0, Req, Res](
+        channel: ZChannel[R],
+        method: MethodDescriptor[Req, Res],
+        options: CallOptions,
+        headers: SafeMetadata,
+        req: ZStream[R0, Status, Req]
+    ): ZStream[R with R0, Status, ResponseFrame[Res]] =
+      Stream
+        .fromEffect(
+          channel.newCall(method, options)
+        )
+        .flatMap(bidiCall(_, headers, req))
+
+  }
+
   def exitHandler[R, Req, Res](
       call: ZClientCall[R, Req, Res]
   )(l: Any, ex: Exit[Status, Any]) = anyExitHandler(call)(l, ex)
@@ -27,31 +154,7 @@ object ClientCalls {
       headers: SafeMetadata,
       req: Req
   ): ZIO[R, Status, Res] =
-    unaryCallWithMetadata(channel, method, options, headers, req).map(_._2)
-
-  def unaryCallWithMetadata[R, Req, Res](
-      channel: ZChannel[R],
-      method: MethodDescriptor[Req, Res],
-      options: CallOptions,
-      headers: SafeMetadata,
-      req: Req
-  ): ZIO[R, Status, (Metadata, Res)] =
-    channel
-      .newCall(method, options)
-      .flatMap(unaryCall(_, headers, req))
-
-  private def unaryCall[R, Req, Res](
-      call: ZClientCall[R, Req, Res],
-      headers: SafeMetadata,
-      req: Req
-  ): ZIO[R, Status, (Metadata, Res)] =
-    ZIO.bracketExit(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
-      call.start(listener, headers) *>
-        call.request(1) *>
-        call.sendMessage(req) *>
-        call.halfClose() *>
-        listener.getValue
-    }
+    withMetadata.unaryCall(channel, method, options, headers, req).map(_.response)
 
   def serverStreamingCall[R, Req, Res](
       channel: ZChannel[R],
@@ -59,40 +162,10 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): ZStream[R, Status, Res]                   =
-    serverStreamingCallWithMetadata(channel, method, options, headers, req)
-      .collect { case Right(x) => x }
-
-  def serverStreamingCallWithMetadata[R, Req, Res](
-      channel: ZChannel[R],
-      method: MethodDescriptor[Req, Res],
-      options: CallOptions,
-      headers: SafeMetadata,
-      req: Req
-  ): ZStream[R, Status, Either[Metadata, Res]] =
-    Stream
-      .fromEffect(channel.newCall(method, options))
-      .flatMap(serverStreamingCall(_, headers, req))
-
-  private def serverStreamingCall[R, Req, Res](
-      call: ZClientCall[R, Req, Res],
-      headers: SafeMetadata,
-      req: Req
-  ): ZStream[R, Status, Either[Metadata, Res]] =
-    Stream
-      .bracketExit(
-        StreamingClientCallListener.make[R, Res](call)
-      )(anyExitHandler[R, Req, Res](call))
-      .flatMap { (listener: StreamingClientCallListener[R, Res]) =>
-        Stream
-          .fromEffect(
-            call.start(listener, headers) *>
-              call.request(1) *>
-              call.sendMessage(req) *>
-              call.halfClose()
-          )
-          .drain ++ listener.stream
-      }
+  ): ZStream[R, Status, Res]     =
+    withMetadata
+      .serverStreamingCall(channel, method, options, headers, req)
+      .collect { case ResponseFrame.Message(x) => x }
 
   def clientStreamingCall[R, R0, Req, Res](
       channel: ZChannel[R],
@@ -101,41 +174,7 @@ object ClientCalls {
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
   ): ZIO[R with R0, Status, Res] =
-    clientStreamingCallWithMetadata(channel, method, options, headers, req).map(_._2)
-
-  def clientStreamingCallWithMetadata[R, R0, Req, Res](
-      channel: ZChannel[R],
-      method: MethodDescriptor[Req, Res],
-      options: CallOptions,
-      headers: SafeMetadata,
-      req: ZStream[R0, Status, Req]
-  ): ZIO[R with R0, Status, (Metadata, Res)] =
-    channel
-      .newCall(method, options)
-      .flatMap(
-        clientStreamingCall(
-          _,
-          headers,
-          req
-        )
-      )
-
-  private def clientStreamingCall[R, R0, Req, Res](
-      call: ZClientCall[R, Req, Res],
-      headers: SafeMetadata,
-      req: ZStream[R0, Status, Req]
-  ): ZIO[R with R0, Status, (Metadata, Res)] =
-    ZIO.bracketExit(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
-      val callStream   = req.tap(call.sendMessage).drain ++ ZStream.fromEffect(call.halfClose()).drain
-      val resultStream = ZStream.fromEffect(listener.getValue)
-
-      call.start(listener, headers) *>
-        call.request(1) *>
-        callStream
-          .merge(resultStream)
-          .runCollect
-          .map(res => res.last)
-    }
+    withMetadata.clientStreamingCall(channel, method, options, headers, req).map(_.response)
 
   def bidiCall[R, R0, Req, Res](
       channel: ZChannel[R],
@@ -143,40 +182,8 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: ZStream[R0, Status, Req]
-  ): ZStream[R with R0, Status, Res]                   =
-    bidiCallWithMetadata(channel, method, options, headers, req)
-      .collect { case Right(x) => x }
-
-  def bidiCallWithMetadata[R, R0, Req, Res](
-      channel: ZChannel[R],
-      method: MethodDescriptor[Req, Res],
-      options: CallOptions,
-      headers: SafeMetadata,
-      req: ZStream[R0, Status, Req]
-  ): ZStream[R with R0, Status, Either[Metadata, Res]] =
-    Stream
-      .fromEffect(
-        channel.newCall(method, options)
-      )
-      .flatMap(bidiCall(_, headers, req))
-
-  private def bidiCall[R, R0, Req, Res](
-      call: ZClientCall[R, Req, Res],
-      headers: SafeMetadata,
-      req: ZStream[R0, Status, Req]
-  ): ZStream[R with R0, Status, Either[Metadata, Res]] =
-    Stream
-      .bracketExit(
-        StreamingClientCallListener.make[R, Res](call)
-      )(anyExitHandler(call))
-      .flatMap { (listener: StreamingClientCallListener[R, Res]) =>
-        val init              = Stream
-          .fromEffect(
-            call.start(listener, headers) *>
-              call.request(1)
-          )
-        val sendRequestStream = (init ++ req.tap(call.sendMessage) ++ Stream
-          .fromEffect(call.halfClose())).drain
-        sendRequestStream.merge(listener.stream)
-      }
+  ): ZStream[R with R0, Status, Res] =
+    withMetadata
+      .bidiCall(channel, method, options, headers, req)
+      .collect { case ResponseFrame.Message(x) => x }
 }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
@@ -1,61 +1,34 @@
 package scalapb.zio_grpc.client
 
-import zio.Runtime
-import zio.Ref
-
-import io.grpc.ClientCall
-import io.grpc.{Metadata, Status}
-import zio.Queue
-import zio.IO
-import StreamingCallState._
+import io.grpc.{ClientCall, Metadata, Status}
+import scalapb.zio_grpc.ResponseFrame
+import zio.{IO, Queue, Runtime, URIO}
 import zio.stream.ZStream
-import zio.URIO
-
-sealed trait StreamingCallState[+Res]
-
-object StreamingCallState {
-  case object Initial extends StreamingCallState[Nothing]
-
-  case class HeadersReceived[Res](headers: Metadata) extends StreamingCallState[Res]
-
-  case class Failure[Res](s: String) extends StreamingCallState[Res]
-}
 
 class StreamingClientCallListener[R, Res](
     runtime: Runtime[R],
     call: ZClientCall[R, _, Res],
-    state: Ref[StreamingCallState[Res]],
-    queue: Queue[Either[(Status, Metadata), Res]]
+    queue: Queue[ResponseFrame[Res]]
 ) extends ClientCall.Listener[Res] {
 
-  override def onHeaders(headers: Metadata): Unit =
-    runtime.unsafeRun(
-      state
-        .update({
-          case Initial            => HeadersReceived(headers)
-          case HeadersReceived(_) => Failure("onHeaders already called")
-          case f @ Failure(_)     => f
-        })
-        .unit
-    )
+  override def onHeaders(headers: Metadata): Unit = {
+    val _ = runtime.unsafeRun(queue.offer(ResponseFrame.Headers(headers)))
+  }
 
   override def onMessage(message: Res): Unit =
-    runtime.unsafeRun(queue.offer(Right(message)) *> call.request(1))
+    runtime.unsafeRun(queue.offer(ResponseFrame.Message(message)) *> call.request(1))
 
-  override def onClose(status: Status, trailers: Metadata): Unit =
-    runtime.unsafeRun(queue.offer(Left((status, trailers))).unit)
+  override def onClose(status: Status, trailers: Metadata): Unit = {
+    val _ = runtime.unsafeRun(queue.offer(ResponseFrame.Trailers(status, trailers)))
+  }
 
-  def stream: ZStream[Any, Status, Either[Metadata, Res]] =
+  def stream: ZStream[Any, Status, ResponseFrame[Res]] =
     ZStream
       .fromQueue(queue)
       .tap {
-        case Left((status, trailers @ _)) =>
-          queue.shutdown *> IO.when(!status.isOk)(IO.fail(status))
-        case _                            => IO.unit
-      }
-      .map {
-        case Left((_, metadata)) => Left(metadata)
-        case otherwise           => otherwise.asInstanceOf[Either[Metadata, Res]]
+        case ResponseFrame.Trailers(status, _) if !status.isOk => queue.shutdown *> IO.fail(status)
+        case ResponseFrame.Trailers(_, _)                      => queue.shutdown
+        case otherwise                                         => IO.unit
       }
 }
 
@@ -65,7 +38,6 @@ object StreamingClientCallListener {
   ): URIO[R, StreamingClientCallListener[R, Res]] =
     for {
       runtime <- zio.ZIO.runtime[R]
-      state   <- Ref.make[StreamingCallState[Res]](Initial)
-      queue   <- Queue.unbounded[Either[(Status, Metadata), Res]]
-    } yield new StreamingClientCallListener(runtime, call, state, queue)
+      queue   <- Queue.unbounded[ResponseFrame[Res]]
+    } yield new StreamingClientCallListener(runtime, call, queue)
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
@@ -2,7 +2,7 @@ package scalapb.zio_grpc
 
 import zio.test._
 import zio._
-import testservice.ZioTestservice.TestServiceClient
+import testservice.ZioTestservice.{TestServiceClient, TestServiceClientWithMetadata}
 import testservice.ZioTestservice.ZTestService
 import testservice._
 import io.grpc.ServerBuilder
@@ -16,45 +16,58 @@ import zio.clock.Clock
 object EnvSpec extends DefaultRunnableSpec with MetadataTests {
   case class User(name: String)
 
-  val getUser = ZIO.access[Has[User]](_.get)
+  case class Context(user: User, response: SafeMetadata)
 
-  object ServiceWithConsole extends ZTestService[Console with Clock, Has[User]] {
-    def unary(request: Request): ZIO[Console with Has[User], Status, Response] =
+  val getUser             = ZIO.access[Has[Context]](_.get.user)
+  val getResponseMetadata = ZIO.access[Has[Context]](_.get.response)
+
+  object ServiceWithConsole extends ZTestService[Console with Clock, Has[Context]] {
+    def unary(request: Request): ZIO[Console with Has[Context], Status, Response] =
       for {
         user <- getUser
+        md   <- getResponseMetadata
+        _    <- md.put(RequestIdKey, "1")
       } yield Response(out = user.name)
 
     def serverStreaming(
         request: Request
-    ): ZStream[Console with Has[User], Status, Response] =
-      ZStream.accessStream { (u: Has[User]) =>
-        ZStream(
-          Response(u.get.name),
-          Response(u.get.name)
-        )
+    ): ZStream[Console with Has[Context], Status, Response] =
+      ZStream.accessStream { (u: Has[Context]) =>
+        ZStream
+          .fromEffect(
+            u.get.response.put(RequestIdKey, "1")
+          )
+          .drain ++
+          ZStream(
+            Response(u.get.user.name),
+            Response(u.get.user.name)
+          )
       }
 
     def clientStreaming(
         request: zio.stream.ZStream[Any, Status, Request]
-    ): ZIO[Has[User], Status, Response] = getUser.map(n => Response(n.name))
+    ): ZIO[Has[Context], Status, Response] =
+      for {
+        n  <- getUser
+        md <- getResponseMetadata
+        _  <- md.put(RequestIdKey, "1")
+      } yield Response(n.name)
 
     def bidiStreaming(
         request: zio.stream.ZStream[Any, Status, Request]
-    ): ZStream[Has[User], Status, Response] =
-      ZStream.accessStream { (u: Has[User]) =>
-        ZStream(
-          Response(u.get.name)
-        )
+    ): ZStream[Has[Context], Status, Response] =
+      ZStream.accessStream { (u: Has[Context]) =>
+        ZStream.fromEffect(u.get.response.put(RequestIdKey, "1")).drain ++ ZStream(Response(u.get.user.name))
       }
   }
 
   val UserKey =
     Metadata.Key.of("user-key", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
 
-  def parseUser(rc: RequestContext): IO[Status, User] =
+  def parseUser(rc: RequestContext): IO[Status, Context] =
     rc.metadata.get(UserKey).flatMap {
       case Some("alice") => IO.fail(Status.PERMISSION_DENIED.withDescription("You are not allowed!"))
-      case Some(name)    => IO.succeed(User(name))
+      case Some(name)    => IO.succeed(Context(User(name), rc.responseMetadata))
       case None          => IO.fail(Status.UNAUTHENTICATED)
     }
 
@@ -75,6 +88,21 @@ object EnvSpec extends DefaultRunnableSpec with MetadataTests {
           )
         )
         TestServiceClient
+          .managed(ch)
+          .orDie
+      }
+    }
+
+  override def clientMetadataLayer: ZLayer[Server, Nothing, TestServiceClientWithMetadata] =
+    ZLayer.fromServiceManaged { (ss: Server.Service) =>
+      ZManaged.fromEffect(ss.port).orDie >>= { (port: Int) =>
+        val ch = ZManagedChannel(
+          ManagedChannelBuilder.forAddress("localhost", port).usePlaintext(),
+          Seq(
+            ZClientInterceptor.headersUpdater((_, _, md) => md.put(UserKey, "bob").unit)
+          )
+        )
+        TestServiceClientWithMetadata
           .managed(ch)
           .orDie
       }

--- a/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
@@ -53,10 +53,7 @@ object EnvSpec extends DefaultRunnableSpec with MetadataTests {
 
   def parseUser(rc: RequestContext): IO[Status, User] =
     rc.metadata.get(UserKey).flatMap {
-      case Some("alice") =>
-        IO.fail(
-          Status.PERMISSION_DENIED.withDescription("You are not allowed!")
-        )
+      case Some("alice") => IO.fail(Status.PERMISSION_DENIED.withDescription("You are not allowed!"))
       case Some(name)    => IO.succeed(User(name))
       case None          => IO.fail(Status.UNAUTHENTICATED)
     }
@@ -87,6 +84,6 @@ object EnvSpec extends DefaultRunnableSpec with MetadataTests {
 
   def spec =
     suite("EnvSpec")(
-      specs: _*
-    ).provideLayer(layers.orDie)
+      specs
+    ).provideCustomLayer(layers.orDie)
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
@@ -6,15 +6,21 @@ import zio.test.TestAspect._
 import zio.duration._
 import zio._
 import zio.stream.Stream
-import testservice.ZioTestservice.TestServiceClient
+import testservice.ZioTestservice.{TestServiceClient, TestServiceClientWithMetadata}
 import testservice._
 import io.grpc.Status
 import TestUtils._
+import io.grpc.Metadata
 
 trait MetadataTests {
   def clientLayer(
       userName: Option[String]
   ): ZLayer[Server, Nothing, TestServiceClient]
+
+  def clientMetadataLayer: ZLayer[Server, Nothing, TestServiceClientWithMetadata]
+
+  val RequestIdKey =
+    Metadata.Key.of("request-id", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
 
   val authClient   = clientLayer(Some("bob"))
   val unauthClient = clientLayer(Some("alice"))
@@ -28,6 +34,36 @@ trait MetadataTests {
     TestServiceClient.serverStreaming(Request()).runCollect
   val clientStreamingEffect = TestServiceClient.clientStreaming(Stream.empty)
   val bidiEffect            = TestServiceClient.bidiStreaming(Stream.empty).runCollect
+
+  val unaryEffectWithMd           =
+    ZioTestservice.TestServiceClientWithMetadata.unary(Request())
+  val serverStreamingEffectWithMd =
+    ZioTestservice.TestServiceClientWithMetadata.serverStreaming(Request()).runCollect
+  val clientStreamingEffectWithMd =
+    ZioTestservice.TestServiceClientWithMetadata.clientStreaming(Stream.empty)
+  val bidiEffectWithMd            =
+    ZioTestservice.TestServiceClientWithMetadata.bidiStreaming(Stream.empty).runCollect
+
+  val properTrailer = Assertion.assertion[Metadata]("trailers")() { md =>
+    md.containsKey(RequestIdKey) && md.get(RequestIdKey) == "1"
+  }
+
+  val properHeader = Assertion.assertion[Metadata]("headers")() { md =>
+    val keys = md.keys()
+    keys.contains("content-type") && keys.contains("grpc-encoding") && keys.contains("grpc-accept-encoding")
+  }
+
+  def checkHeaderFrame(r: ResponseFrame[Response]) =
+    assert(r.isInstanceOf[ResponseFrame.Headers])(isTrue) &&
+      assert(r.asInstanceOf[ResponseFrame.Headers].headers)(properHeader)
+
+  def checkTrailerFrame(r: ResponseFrame[Response]) =
+    assert(r.isInstanceOf[ResponseFrame.Trailers])(isTrue) &&
+      assert(r.asInstanceOf[ResponseFrame.Trailers].trailers)(properTrailer)
+
+  def checkMessageFrame(r: ResponseFrame[Response]) =
+    assert(r.isInstanceOf[ResponseFrame.Message[Response]])(isTrue) &&
+      assert(r.asInstanceOf[ResponseFrame.Message[Response]].message)(equalTo(Response("bob")))
 
   def permissionDeniedSuite =
     suite("unauthorized request fail for")(
@@ -62,7 +98,7 @@ trait MetadataTests {
     ).provideLayer(unsetClient)
 
   def authenticatedSuite =
-    suite("authorized request fail for")(
+    suite("authorized request")(
       testM("unary") {
         assertM(unaryEffect)(equalTo(Response("bob")))
       },
@@ -79,9 +115,47 @@ trait MetadataTests {
       }
     ).provideLayer(authClient)
 
+  def metadataSuite =
+    suite("response metadata")(
+      testM("unary") {
+        for {
+          result                                      <- unaryEffectWithMd
+          ResponseContext(headers, response, trailers) = result
+        } yield assert(response)(equalTo(Response("bob"))) &&
+          assert(headers)(properHeader) &&
+          assert(trailers)(properTrailer)
+      },
+      testM("server streaming") {
+        for {
+          result <- serverStreamingEffectWithMd
+        } yield assert(result.size)(equalTo(4)) &&
+          checkHeaderFrame(result(0)) &&
+          checkMessageFrame(result(1)) &&
+          checkMessageFrame(result(2)) &&
+          checkTrailerFrame(result(3))
+      },
+      testM("client streaming") {
+        for {
+          result                                      <- unaryEffectWithMd
+          ResponseContext(headers, response, trailers) = result
+        } yield assert(response)(equalTo(Response("bob"))) &&
+          assert(headers)(properHeader) &&
+          assert(trailers)(properTrailer)
+      },
+      testM("bidi streaming") {
+        for {
+          result                           <- bidiEffectWithMd
+          Chunk(headers, message, trailers) = result
+        } yield checkHeaderFrame(headers) &&
+          checkMessageFrame(message) &&
+          checkTrailerFrame(trailers)
+      }
+    ).provideLayer(clientMetadataLayer)
+
   val specs = suite("Metadata")(
     permissionDeniedSuite,
     unauthenticatedSuite,
-    authenticatedSuite
+    authenticatedSuite,
+    metadataSuite
   ) @@ timeout(10.seconds)
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
@@ -2,6 +2,8 @@ package scalapb.zio_grpc
 
 import zio.test._
 import zio.test.Assertion._
+import zio.test.TestAspect._
+import zio.duration._
 import zio._
 import zio.stream.Stream
 import testservice.ZioTestservice.TestServiceClient
@@ -77,9 +79,9 @@ trait MetadataTests {
       }
     ).provideLayer(authClient)
 
-  val specs = Seq(
+  val specs = suite("Metadata")(
     permissionDeniedSuite,
     unauthenticatedSuite,
     authenticatedSuite
-  )
+  ) @@ timeout(10.seconds)
 }


### PR DESCRIPTION
@thesamet even though we can now send trailers, there is no way to consume them in the client 😓 

I think the generated code should offer support for it but I would like your opinion first. Since it would change the result type, we can either:

- add `*WithMetadata` methods on the client impl, or
- generate an "advanced" client impl with the same method names that yields the metadata