### PR TITLE
Support metadata(trailers) on error status

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
@@ -26,7 +26,8 @@ class StreamingClientCallListener[R, Res](
     ZStream
       .fromQueue(queue)
       .tap {
-        case ResponseFrame.Trailers(status, _) if !status.isOk => queue.shutdown *> IO.fail(status)
+        case ResponseFrame.Trailers(status, trailers) if !status.isOk =>
+          queue.shutdown *> IO.fail(status.withCause(status.asException(trailers)))
         case ResponseFrame.Trailers(_, _)                      => queue.shutdown
         case _                                                 => IO.unit
       }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/UnaryClientCallListener.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/UnaryClientCallListener.scala
@@ -57,7 +57,7 @@ class UnaryClientCallListener[Res](
     runtime.unsafeRun {
       for {
         s <- state.get
-        _ <- if (!status.isOk) promise.fail(status)
+        _ <- if (!status.isOk) promise.fail(status.withCause(status.asException(trailers)))
              else
                s match {
                  case ResponseReceived(headers, message) =>

--- a/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
@@ -27,6 +27,7 @@ object EnvSpec extends DefaultRunnableSpec with MetadataTests {
         user <- getUser
         md   <- getResponseMetadata
         _    <- md.put(RequestIdKey, "1")
+        _    <- ZIO.fail(Status.FAILED_PRECONDITION).when(user.name == "Eve")
       } yield Response(out = user.name)
 
     def serverStreaming(
@@ -35,7 +36,8 @@ object EnvSpec extends DefaultRunnableSpec with MetadataTests {
       ZStream.accessStream { (u: Has[Context]) =>
         ZStream
           .fromEffect(
-            u.get.response.put(RequestIdKey, "1")
+              u.get.response.put(RequestIdKey, "1")
+                  .andThen(ZIO.fail(Status.FAILED_PRECONDITION).when(u.get.user.name == "Eve"))
           )
           .drain ++
           ZStream(
@@ -48,16 +50,20 @@ object EnvSpec extends DefaultRunnableSpec with MetadataTests {
         request: zio.stream.ZStream[Any, Status, Request]
     ): ZIO[Has[Context], Status, Response] =
       for {
-        n  <- getUser
+        user  <- getUser
         md <- getResponseMetadata
         _  <- md.put(RequestIdKey, "1")
-      } yield Response(n.name)
+        _ <- ZIO.fail(Status.FAILED_PRECONDITION).when(user.name == "Eve")
+      } yield Response(user.name)
 
     def bidiStreaming(
         request: zio.stream.ZStream[Any, Status, Request]
     ): ZStream[Has[Context], Status, Response] =
       ZStream.accessStream { (u: Has[Context]) =>
-        ZStream.fromEffect(u.get.response.put(RequestIdKey, "1")).drain ++ ZStream(Response(u.get.user.name))
+        ZStream.fromEffect(
+          u.get.response.put(RequestIdKey, "1")
+              .andThen(ZIO.fail(Status.FAILED_PRECONDITION).when(u.get.user.name == "Eve"))
+        ).drain ++ ZStream(Response(u.get.user.name))
       }
   }
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
@@ -24,10 +24,12 @@ trait MetadataTests {
 
   val authClient   = clientLayer(Some("bob"))
   val unauthClient = clientLayer(Some("alice"))
+  val errorClient = clientLayer(Some("Eve"))
   val unsetClient  = clientLayer(None)
 
   val permissionDenied = fails(hasStatusCode(Status.PERMISSION_DENIED))
   val unauthenticated  = fails(hasStatusCode(Status.UNAUTHENTICATED))
+  val errorWithTrailers = fails(hasStatusCode(Status.FAILED_PRECONDITION) && hasTrailerValue(RequestIdKey, "1"))
 
   val unaryEffect           = TestServiceClient.unary(Request())
   val serverStreamingEffect =
@@ -115,6 +117,23 @@ trait MetadataTests {
       }
     ).provideLayer(authClient)
 
+
+  def errorWithTrailersSuite =
+    suite("errro response with trailers")(
+      testM("unary") {
+        assertM(unaryEffect.run)(errorWithTrailers)
+      },
+      testM("server streaming") {
+        assertM(serverStreamingEffect.run)(errorWithTrailers)
+      },
+      testM("client streaming") {
+        assertM(clientStreamingEffect.run)(errorWithTrailers)
+      },
+      testM("bidi streaming") {
+        assertM(bidiEffect.run)(errorWithTrailers)
+      }
+    ).provideLayer(errorClient)
+
   def metadataSuite =
     suite("response metadata")(
       testM("unary") {
@@ -156,6 +175,7 @@ trait MetadataTests {
     permissionDeniedSuite,
     unauthenticatedSuite,
     authenticatedSuite,
+    errorWithTrailersSuite,
     metadataSuite
-  ) @@ timeout(10.seconds)
+  ) @@ timeout(120.seconds)
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
@@ -1,8 +1,12 @@
 package scalapb.zio_grpc
 
 import zio.test.Assertion._
-import io.grpc.Status
+import io.grpc.{Metadata, Status, StatusException}
 import io.grpc.Status.Code
+import zio.test.Assertion
+import zio.test.AssertionM.Render.param
+
+import scala.collection.JavaConverters
 
 object TestUtils {
   def hasStatusCode(c: Status) =
@@ -10,4 +14,7 @@ object TestUtils {
 
   def hasDescription(d: String) =
     hasField[Status, String]("description", d => Option(d.getDescription()).getOrElse("GotNull"), equalTo(d))
+
+  def hasTrailerValue[T](key: Metadata.Key[T], value: T) =
+    hasField[Status, T]("trailers", s => Status.trailersFromThrowable(s.getCause).get(key), equalTo(value))
 }


### PR DESCRIPTION
Hello, our team is using zio-grpc on our micro service architecture. We found the problem that the response status on error(not Ok response) does not have trailers.
So, we propose the patch that the error status has trailers on its cause.
