### PR TITLE
change Status to StatusRuntimeException(breaking change)

### DIFF
--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -61,7 +61,7 @@ class ZioFilePrinter(
   val ClientCalls         = "scalapb.zio_grpc.client.ClientCalls"
   val Duration            = "zio.Duration"
   val SafeMetadata        = "scalapb.zio_grpc.SafeMetadata"
-  val StatusException     = "io.grpc.StatusException"
+  val StatusRuntimeException     = "io.grpc.StatusRuntimeException"
   val Deadline            = "io.grpc.Deadline"
   val methodDescriptor    = "io.grpc.MethodDescriptor"
   val RequestContext      = "scalapb.zio_grpc.RequestContext"
@@ -673,13 +673,13 @@ class ZioFilePrinter(
 
   def stream(res: String, envType: String) =
     envType match {
-      case "Any" => s"_root_.zio.stream.Stream[$StatusException, $res]"
-      case r     => s"_root_.zio.stream.ZStream[$r, $StatusException, $res]"
+      case "Any" => s"_root_.zio.stream.Stream[$StatusRuntimeException, $res]"
+      case r     => s"_root_.zio.stream.ZStream[$r, $StatusRuntimeException, $res]"
     }
 
   def io(res: String, envType: String) =
     envType match {
-      case "Any" => s"_root_.zio.IO[$StatusException, $res]"
-      case r     => s"_root_.zio.ZIO[$r, $StatusException, $res]"
+      case "Any" => s"_root_.zio.IO[$StatusRuntimeException, $res]"
+      case r     => s"_root_.zio.ZIO[$r, $StatusRuntimeException, $res]"
     }
 }

--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -61,7 +61,7 @@ class ZioFilePrinter(
   val ClientCalls         = "scalapb.zio_grpc.client.ClientCalls"
   val Duration            = "zio.Duration"
   val SafeMetadata        = "scalapb.zio_grpc.SafeMetadata"
-  val Status              = "io.grpc.Status"
+  val StatusException     = "io.grpc.StatusException"
   val Deadline            = "io.grpc.Deadline"
   val methodDescriptor    = "io.grpc.MethodDescriptor"
   val RequestContext      = "scalapb.zio_grpc.RequestContext"
@@ -673,13 +673,13 @@ class ZioFilePrinter(
 
   def stream(res: String, envType: String) =
     envType match {
-      case "Any" => s"_root_.zio.stream.Stream[$Status, $res]"
-      case r     => s"_root_.zio.stream.ZStream[$r, $Status, $res]"
+      case "Any" => s"_root_.zio.stream.Stream[$StatusException, $res]"
+      case r     => s"_root_.zio.stream.ZStream[$r, $StatusException, $res]"
     }
 
   def io(res: String, envType: String) =
     envType match {
-      case "Any" => s"_root_.zio.IO[$Status, $res]"
-      case r     => s"_root_.zio.ZIO[$r, $Status, $res]"
+      case "Any" => s"_root_.zio.IO[$StatusException, $res]"
+      case r     => s"_root_.zio.ZIO[$r, $StatusException, $res]"
     }
 }

--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -56,23 +56,23 @@ class ZioFilePrinter(
 ) {
   import implicits._
 
-  val Channel             = "io.grpc.Channel"
-  val CallOptions         = "io.grpc.CallOptions"
-  val ClientCalls         = "scalapb.zio_grpc.client.ClientCalls"
-  val Duration            = "zio.Duration"
-  val SafeMetadata        = "scalapb.zio_grpc.SafeMetadata"
-  val StatusRuntimeException     = "io.grpc.StatusRuntimeException"
-  val Deadline            = "io.grpc.Deadline"
-  val methodDescriptor    = "io.grpc.MethodDescriptor"
-  val RequestContext      = "scalapb.zio_grpc.RequestContext"
-  val ZClientCall         = "scalapb.zio_grpc.client.ZClientCall"
-  val ZManagedChannel     = "scalapb.zio_grpc.ZManagedChannel"
-  val ZChannel            = "scalapb.zio_grpc.ZChannel"
-  val ZTransform          = "scalapb.zio_grpc.ZTransform"
-  val Transform           = "scalapb.zio_grpc.Transform"
-  val Nanos               = "java.util.concurrent.TimeUnit.NANOSECONDS"
-  val serverServiceDef    = "_root_.io.grpc.ServerServiceDefinition"
-  private val OuterObject =
+  val Channel                = "io.grpc.Channel"
+  val CallOptions            = "io.grpc.CallOptions"
+  val ClientCalls            = "scalapb.zio_grpc.client.ClientCalls"
+  val Duration               = "zio.Duration"
+  val SafeMetadata           = "scalapb.zio_grpc.SafeMetadata"
+  val StatusRuntimeException = "io.grpc.StatusRuntimeException"
+  val Deadline               = "io.grpc.Deadline"
+  val methodDescriptor       = "io.grpc.MethodDescriptor"
+  val RequestContext         = "scalapb.zio_grpc.RequestContext"
+  val ZClientCall            = "scalapb.zio_grpc.client.ZClientCall"
+  val ZManagedChannel        = "scalapb.zio_grpc.ZManagedChannel"
+  val ZChannel               = "scalapb.zio_grpc.ZChannel"
+  val ZTransform             = "scalapb.zio_grpc.ZTransform"
+  val Transform              = "scalapb.zio_grpc.Transform"
+  val Nanos                  = "java.util.concurrent.TimeUnit.NANOSECONDS"
+  val serverServiceDef       = "_root_.io.grpc.ServerServiceDefinition"
+  private val OuterObject    =
     file.scalaPackage / s"Zio${NameUtils.snakeCaseToCamelCase(baseName(file.getName), true)}"
 
   def scalaFileName =

--- a/core/src/main/scala/scalapb/zio_grpc/GIO.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/GIO.scala
@@ -5,7 +5,7 @@ import zio.{Task, ZIO, IO}
 
 object GIO {
   def fromTask[A](task: Task[A]): IO[StatusRuntimeException, A] =
-    task.mapError(e => Status.INTERNAL.withDescription(e.getMessage).withCause(e).asRuntimeException())
+    task.mapError(e => new StatusRuntimeException(Status.INTERNAL.withDescription(e.getMessage).withCause(e)))
 
   @deprecated("use attempt", "0.6.0")
   def effect[A](effect: => A): IO[StatusRuntimeException, A] = attempt(effect)

--- a/core/src/main/scala/scalapb/zio_grpc/GIO.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/GIO.scala
@@ -1,7 +1,7 @@
 package scalapb.zio_grpc
 
 import io.grpc.{Status, StatusRuntimeException}
-import zio.{Task, ZIO, IO}
+import zio.{IO, Task, ZIO}
 
 object GIO {
   def fromTask[A](task: Task[A]): IO[StatusRuntimeException, A] =

--- a/core/src/main/scala/scalapb/zio_grpc/GIO.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/GIO.scala
@@ -1,14 +1,14 @@
 package scalapb.zio_grpc
 
 import io.grpc.{Status, StatusException}
-import zio.{Task, ZIO}
+import zio.{Task, ZIO, IO}
 
 object GIO {
-  def fromTask[A](task: Task[A]) =
+  def fromTask[A](task: Task[A]): IO[StatusException, A] =
     task.mapError(e => Status.INTERNAL.withDescription(e.getMessage).withCause(e).asException())
 
   @deprecated("use attempt", "0.6.0")
-  def effect[A](effect: => A) = attempt(effect)
+  def effect[A](effect: => A): IO[StatusException, A] = attempt(effect)
 
-  def attempt[A](effect: => A) = fromTask(ZIO.attempt(effect))
+  def attempt[A](effect: => A): IO[StatusException, A] = fromTask(ZIO.attempt(effect))
 }

--- a/core/src/main/scala/scalapb/zio_grpc/GIO.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/GIO.scala
@@ -1,12 +1,11 @@
 package scalapb.zio_grpc
 
-import zio.Task
-import zio.ZIO
-import io.grpc.Status
+import io.grpc.{Status, StatusException}
+import zio.{Task, ZIO}
 
 object GIO {
   def fromTask[A](task: Task[A]) =
-    task.mapError(e => Status.INTERNAL.withDescription(e.getMessage).withCause(e))
+    task.mapError(e => Status.INTERNAL.withDescription(e.getMessage).withCause(e).asException())
 
   @deprecated("use attempt", "0.6.0")
   def effect[A](effect: => A) = attempt(effect)

--- a/core/src/main/scala/scalapb/zio_grpc/GIO.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/GIO.scala
@@ -1,14 +1,14 @@
 package scalapb.zio_grpc
 
-import io.grpc.{Status, StatusException}
+import io.grpc.{Status, StatusRuntimeException}
 import zio.{Task, ZIO, IO}
 
 object GIO {
-  def fromTask[A](task: Task[A]): IO[StatusException, A] =
-    task.mapError(e => Status.INTERNAL.withDescription(e.getMessage).withCause(e).asException())
+  def fromTask[A](task: Task[A]): IO[StatusRuntimeException, A] =
+    task.mapError(e => Status.INTERNAL.withDescription(e.getMessage).withCause(e).asRuntimeException())
 
   @deprecated("use attempt", "0.6.0")
-  def effect[A](effect: => A): IO[StatusException, A] = attempt(effect)
+  def effect[A](effect: => A): IO[StatusRuntimeException, A] = attempt(effect)
 
-  def attempt[A](effect: => A): IO[StatusException, A] = fromTask(ZIO.attempt(effect))
+  def attempt[A](effect: => A): IO[StatusRuntimeException, A] = fromTask(ZIO.attempt(effect))
 }

--- a/core/src/main/scala/scalapb/zio_grpc/ZClientInterceptor.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/ZClientInterceptor.scala
@@ -1,10 +1,8 @@
 package scalapb.zio_grpc
 
-import io.grpc.MethodDescriptor
-import io.grpc.CallOptions
-import zio.IO
-import io.grpc.Status
+import io.grpc.{CallOptions, MethodDescriptor, StatusException}
 import scalapb.zio_grpc.client.ZClientCall
+import zio.IO
 
 abstract class ZClientInterceptor {
   self =>
@@ -20,7 +18,7 @@ object ZClientInterceptor {
       effect: (
           MethodDescriptor[_, _],
           CallOptions
-      ) => IO[Status, SafeMetadata]
+      ) => IO[StatusException, SafeMetadata]
   ): ZClientInterceptor =
     new ZClientInterceptor {
       def interceptCall[Req, Res](
@@ -39,7 +37,7 @@ object ZClientInterceptor {
           MethodDescriptor[_, _],
           CallOptions,
           SafeMetadata
-      ) => IO[Status, Unit]
+      ) => IO[StatusException, Unit]
   ): ZClientInterceptor =
     new ZClientInterceptor {
       def interceptCall[Req, Res](

--- a/core/src/main/scala/scalapb/zio_grpc/ZClientInterceptor.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/ZClientInterceptor.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc
 
-import io.grpc.{CallOptions, MethodDescriptor, StatusException}
+import io.grpc.{CallOptions, MethodDescriptor, StatusRuntimeException}
 import scalapb.zio_grpc.client.ZClientCall
 import zio.IO
 
@@ -18,7 +18,7 @@ object ZClientInterceptor {
       effect: (
           MethodDescriptor[_, _],
           CallOptions
-      ) => IO[StatusException, SafeMetadata]
+      ) => IO[StatusRuntimeException, SafeMetadata]
   ): ZClientInterceptor =
     new ZClientInterceptor {
       def interceptCall[Req, Res](
@@ -37,7 +37,7 @@ object ZClientInterceptor {
           MethodDescriptor[_, _],
           CallOptions,
           SafeMetadata
-      ) => IO[StatusException, Unit]
+      ) => IO[StatusRuntimeException, Unit]
   ): ZClientInterceptor =
     new ZClientInterceptor {
       def interceptCall[Req, Res](

--- a/core/src/main/scala/scalapb/zio_grpc/ZGeneratedService.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/ZGeneratedService.scala
@@ -2,7 +2,7 @@ package scalapb.zio_grpc
 
 import zio.UIO
 import zio.IO
-import io.grpc.{ServerServiceDefinition, StatusException}
+import io.grpc.{ServerServiceDefinition, StatusRuntimeException}
 
 trait ZGeneratedService[-C, S[-_]] {
   this: S[C] =>
@@ -11,7 +11,7 @@ trait ZGeneratedService[-C, S[-_]] {
 
   def transform(t: Transform): S[C] = transform[C](t.toZTransform[C])
 
-  def transformContextZIO[ContextOut](f: ContextOut => IO[StatusException, C]): S[ContextOut] = transform(ZTransform(f))
+  def transformContextZIO[ContextOut](f: ContextOut => IO[StatusRuntimeException, C]): S[ContextOut] = transform(ZTransform(f))
 
   def transformContext[ContextOut](f: ContextOut => C): S[ContextOut] = transformContextZIO(c => zio.ZIO.succeed(f(c)))
 }

--- a/core/src/main/scala/scalapb/zio_grpc/ZGeneratedService.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/ZGeneratedService.scala
@@ -11,7 +11,9 @@ trait ZGeneratedService[-C, S[-_]] {
 
   def transform(t: Transform): S[C] = transform[C](t.toZTransform[C])
 
-  def transformContextZIO[ContextOut](f: ContextOut => IO[StatusRuntimeException, C]): S[ContextOut] = transform(ZTransform(f))
+  def transformContextZIO[ContextOut](f: ContextOut => IO[StatusRuntimeException, C]): S[ContextOut] = transform(
+    ZTransform(f)
+  )
 
   def transformContext[ContextOut](f: ContextOut => C): S[ContextOut] = transformContextZIO(c => zio.ZIO.succeed(f(c)))
 }

--- a/core/src/main/scala/scalapb/zio_grpc/ZGeneratedService.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/ZGeneratedService.scala
@@ -2,8 +2,7 @@ package scalapb.zio_grpc
 
 import zio.UIO
 import zio.IO
-import io.grpc.ServerServiceDefinition
-import io.grpc.Status
+import io.grpc.{ServerServiceDefinition, StatusException}
 
 trait ZGeneratedService[-C, S[-_]] {
   this: S[C] =>
@@ -12,7 +11,7 @@ trait ZGeneratedService[-C, S[-_]] {
 
   def transform(t: Transform): S[C] = transform[C](t.toZTransform[C])
 
-  def transformContextZIO[ContextOut](f: ContextOut => IO[Status, C]): S[ContextOut] = transform(ZTransform(f))
+  def transformContextZIO[ContextOut](f: ContextOut => IO[StatusException, C]): S[ContextOut] = transform(ZTransform(f))
 
   def transformContext[ContextOut](f: ContextOut => C): S[ContextOut] = transformContextZIO(c => zio.ZIO.succeed(f(c)))
 }

--- a/core/src/main/scala/scalapb/zio_grpc/package.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/package.scala
@@ -1,13 +1,13 @@
 package scalapb
 
-import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import zio.stream.Stream
 import zio.{IO, Scope, ZIO}
 
 package object zio_grpc {
-  type GIO[A] = IO[StatusException, A]
+  type GIO[A] = IO[StatusRuntimeException, A]
 
-  type GStream[A] = Stream[StatusException, A]
+  type GStream[A] = Stream[StatusRuntimeException, A]
 
   type ZManagedChannel = ZIO[Scope, Throwable, ZChannel]
 

--- a/core/src/main/scala/scalapb/zio_grpc/package.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/package.scala
@@ -1,13 +1,13 @@
 package scalapb
 
-import io.grpc.Status
-import zio.{IO, Scope, ZIO}
+import io.grpc.StatusException
 import zio.stream.Stream
+import zio.{IO, Scope, ZIO}
 
 package object zio_grpc {
-  type GIO[A] = IO[Status, A]
+  type GIO[A] = IO[StatusException, A]
 
-  type GStream[A] = Stream[Status, A]
+  type GStream[A] = Stream[StatusException, A]
 
   type ZManagedChannel = ZIO[Scope, Throwable, ZChannel]
 

--- a/core/src/main/scala/scalapb/zio_grpc/transforms.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/transforms.scala
@@ -2,7 +2,7 @@ package scalapb.zio_grpc
 
 import zio.ZIO
 import zio.stream.ZStream
-import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 
 /** Describes a transformation for all effects and streams of a service.
   *
@@ -11,33 +11,33 @@ import io.grpc.StatusException
   */
 trait Transform {
   self =>
-  def effect[A](io: ZIO[Any, StatusException, A]): ZIO[Any, StatusException, A]
-  def stream[A](io: ZStream[Any, StatusException, A]): ZStream[Any, StatusException, A]
+  def effect[A](io: ZIO[Any, StatusRuntimeException, A]): ZIO[Any, StatusRuntimeException, A]
+  def stream[A](io: ZStream[Any, StatusRuntimeException, A]): ZStream[Any, StatusRuntimeException, A]
 
   // Converts this Transform to ZTransform that transforms the effects like this, but
   // leaves the Context unchanged.
   def toZTransform[Context]: ZTransform[Context, Context] = new ZTransform[Context, Context] {
-    def effect[A](io: Context => ZIO[Any, StatusException, A]): Context => ZIO[Any, StatusException, A] = { c =>
+    def effect[A](io: Context => ZIO[Any, StatusRuntimeException, A]): Context => ZIO[Any, StatusRuntimeException, A] = { c =>
       self.effect(io(c))
     }
 
-    def stream[A](io: Context => ZStream[Any, StatusException, A]): Context => ZStream[Any, StatusException, A] = { c =>
+    def stream[A](io: Context => ZStream[Any, StatusRuntimeException, A]): Context => ZStream[Any, StatusRuntimeException, A] = { c =>
       self.stream(io(c))
     }
   }
 
   def andThen(other: Transform): Transform = new Transform {
-    def effect[A](io: ZIO[Any, StatusException, A]): ZIO[Any, StatusException, A] = other.effect(self.effect(io))
+    def effect[A](io: ZIO[Any, StatusRuntimeException, A]): ZIO[Any, StatusRuntimeException, A] = other.effect(self.effect(io))
 
-    def stream[A](io: ZStream[Any, StatusException, A]): ZStream[Any, StatusException, A] = other.stream(self.stream(io))
+    def stream[A](io: ZStream[Any, StatusRuntimeException, A]): ZStream[Any, StatusRuntimeException, A] = other.stream(self.stream(io))
   }
 }
 
 object Transform {
   def fromZTransform(ct: ZTransform[Any, Any]) = new Transform {
-    def effect[A](io: ZIO[Any, StatusException, A]): ZIO[Any, StatusException, A] = ct.effect(_ => io)(())
+    def effect[A](io: ZIO[Any, StatusRuntimeException, A]): ZIO[Any, StatusRuntimeException, A] = ct.effect(_ => io)(())
 
-    def stream[A](io: ZStream[Any, StatusException, A]): ZStream[Any, StatusException, A] = ct.stream(_ => io)(())
+    def stream[A](io: ZStream[Any, StatusRuntimeException, A]): ZStream[Any, StatusRuntimeException, A] = ct.stream(_ => io)(())
   }
 }
 
@@ -48,30 +48,30 @@ object Transform {
   */
 trait ZTransform[+ContextIn, -ContextOut] {
   self =>
-  def effect[A](io: ContextIn => ZIO[Any, StatusException, A]): (ContextOut => ZIO[Any, StatusException, A])
-  def stream[A](io: ContextIn => ZStream[Any, StatusException, A]): (ContextOut => ZStream[Any, StatusException, A])
+  def effect[A](io: ContextIn => ZIO[Any, StatusRuntimeException, A]): (ContextOut => ZIO[Any, StatusRuntimeException, A])
+  def stream[A](io: ContextIn => ZStream[Any, StatusRuntimeException, A]): (ContextOut => ZStream[Any, StatusRuntimeException, A])
 
   def andThen[ContextIn2 <: ContextOut, ContextOut2](
       other: ZTransform[ContextIn2, ContextOut2]
   ): ZTransform[ContextIn, ContextOut2] = new ZTransform[ContextIn, ContextOut2] {
-    def effect[A](io: ContextIn => ZIO[Any, StatusException, A]): ContextOut2 => ZIO[Any, StatusException, A] =
+    def effect[A](io: ContextIn => ZIO[Any, StatusRuntimeException, A]): ContextOut2 => ZIO[Any, StatusRuntimeException, A] =
       other.effect(self.effect(io))
 
-    def stream[A](io: ContextIn => ZStream[Any, StatusException, A]): ContextOut2 => ZStream[Any, StatusException, A] =
+    def stream[A](io: ContextIn => ZStream[Any, StatusRuntimeException, A]): ContextOut2 => ZStream[Any, StatusRuntimeException, A] =
       other.stream(self.stream(io))
   }
 }
 
 object ZTransform {
   // Returns a ZTransform that effectfully transforms the context parameter
-  def apply[ContextIn, ContextOut](f: ContextOut => ZIO[Any, StatusException, ContextIn]): ZTransform[ContextIn, ContextOut] =
+  def apply[ContextIn, ContextOut](f: ContextOut => ZIO[Any, StatusRuntimeException, ContextIn]): ZTransform[ContextIn, ContextOut] =
     new ZTransform[ContextIn, ContextOut] {
-      def effect[A](io: ContextIn => ZIO[Any, StatusException, A]): ContextOut => ZIO[Any, StatusException, A] = {
+      def effect[A](io: ContextIn => ZIO[Any, StatusRuntimeException, A]): ContextOut => ZIO[Any, StatusRuntimeException, A] = {
         (context: ContextOut) =>
           f(context).flatMap(io)
       }
 
-      def stream[A](io: ContextIn => ZStream[Any, StatusException, A]): ContextOut => ZStream[Any, StatusException, A] = {
+      def stream[A](io: ContextIn => ZStream[Any, StatusRuntimeException, A]): ContextOut => ZStream[Any, StatusRuntimeException, A] = {
         (context: ContextOut) =>
           ZStream.fromZIO(f(context)).flatMap(io)
       }

--- a/core/src/main/scala/scalapb/zio_grpc/transforms.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/transforms.scala
@@ -2,7 +2,7 @@ package scalapb.zio_grpc
 
 import zio.ZIO
 import zio.stream.ZStream
-import io.grpc.Status
+import io.grpc.StatusException
 
 /** Describes a transformation for all effects and streams of a service.
   *
@@ -11,33 +11,33 @@ import io.grpc.Status
   */
 trait Transform {
   self =>
-  def effect[A](io: ZIO[Any, Status, A]): ZIO[Any, Status, A]
-  def stream[A](io: ZStream[Any, Status, A]): ZStream[Any, Status, A]
+  def effect[A](io: ZIO[Any, StatusException, A]): ZIO[Any, StatusException, A]
+  def stream[A](io: ZStream[Any, StatusException, A]): ZStream[Any, StatusException, A]
 
   // Converts this Transform to ZTransform that transforms the effects like this, but
   // leaves the Context unchanged.
   def toZTransform[Context]: ZTransform[Context, Context] = new ZTransform[Context, Context] {
-    def effect[A](io: Context => ZIO[Any, Status, A]): Context => ZIO[Any, Status, A] = { c =>
+    def effect[A](io: Context => ZIO[Any, StatusException, A]): Context => ZIO[Any, StatusException, A] = { c =>
       self.effect(io(c))
     }
 
-    def stream[A](io: Context => ZStream[Any, Status, A]): Context => ZStream[Any, Status, A] = { c =>
+    def stream[A](io: Context => ZStream[Any, StatusException, A]): Context => ZStream[Any, StatusException, A] = { c =>
       self.stream(io(c))
     }
   }
 
   def andThen(other: Transform): Transform = new Transform {
-    def effect[A](io: ZIO[Any, Status, A]): ZIO[Any, Status, A] = other.effect(self.effect(io))
+    def effect[A](io: ZIO[Any, StatusException, A]): ZIO[Any, StatusException, A] = other.effect(self.effect(io))
 
-    def stream[A](io: ZStream[Any, Status, A]): ZStream[Any, Status, A] = other.stream(self.stream(io))
+    def stream[A](io: ZStream[Any, StatusException, A]): ZStream[Any, StatusException, A] = other.stream(self.stream(io))
   }
 }
 
 object Transform {
   def fromZTransform(ct: ZTransform[Any, Any]) = new Transform {
-    def effect[A](io: ZIO[Any, Status, A]): ZIO[Any, Status, A] = ct.effect(_ => io)(())
+    def effect[A](io: ZIO[Any, StatusException, A]): ZIO[Any, StatusException, A] = ct.effect(_ => io)(())
 
-    def stream[A](io: ZStream[Any, Status, A]): ZStream[Any, Status, A] = ct.stream(_ => io)(())
+    def stream[A](io: ZStream[Any, StatusException, A]): ZStream[Any, StatusException, A] = ct.stream(_ => io)(())
   }
 }
 
@@ -48,30 +48,30 @@ object Transform {
   */
 trait ZTransform[+ContextIn, -ContextOut] {
   self =>
-  def effect[A](io: ContextIn => ZIO[Any, Status, A]): (ContextOut => ZIO[Any, Status, A])
-  def stream[A](io: ContextIn => ZStream[Any, Status, A]): (ContextOut => ZStream[Any, Status, A])
+  def effect[A](io: ContextIn => ZIO[Any, StatusException, A]): (ContextOut => ZIO[Any, StatusException, A])
+  def stream[A](io: ContextIn => ZStream[Any, StatusException, A]): (ContextOut => ZStream[Any, StatusException, A])
 
   def andThen[ContextIn2 <: ContextOut, ContextOut2](
       other: ZTransform[ContextIn2, ContextOut2]
   ): ZTransform[ContextIn, ContextOut2] = new ZTransform[ContextIn, ContextOut2] {
-    def effect[A](io: ContextIn => ZIO[Any, Status, A]): ContextOut2 => ZIO[Any, Status, A] =
+    def effect[A](io: ContextIn => ZIO[Any, StatusException, A]): ContextOut2 => ZIO[Any, StatusException, A] =
       other.effect(self.effect(io))
 
-    def stream[A](io: ContextIn => ZStream[Any, Status, A]): ContextOut2 => ZStream[Any, Status, A] =
+    def stream[A](io: ContextIn => ZStream[Any, StatusException, A]): ContextOut2 => ZStream[Any, StatusException, A] =
       other.stream(self.stream(io))
   }
 }
 
 object ZTransform {
   // Returns a ZTransform that effectfully transforms the context parameter
-  def apply[ContextIn, ContextOut](f: ContextOut => ZIO[Any, Status, ContextIn]): ZTransform[ContextIn, ContextOut] =
+  def apply[ContextIn, ContextOut](f: ContextOut => ZIO[Any, StatusException, ContextIn]): ZTransform[ContextIn, ContextOut] =
     new ZTransform[ContextIn, ContextOut] {
-      def effect[A](io: ContextIn => ZIO[Any, Status, A]): ContextOut => ZIO[Any, Status, A] = {
+      def effect[A](io: ContextIn => ZIO[Any, StatusException, A]): ContextOut => ZIO[Any, StatusException, A] = {
         (context: ContextOut) =>
           f(context).flatMap(io)
       }
 
-      def stream[A](io: ContextIn => ZStream[Any, Status, A]): ContextOut => ZStream[Any, Status, A] = {
+      def stream[A](io: ContextIn => ZStream[Any, StatusException, A]): ContextOut => ZStream[Any, StatusException, A] = {
         (context: ContextOut) =>
           ZStream.fromZIO(f(context)).flatMap(io)
       }

--- a/core/src/main/scala/scalapb/zio_grpc/transforms.scala
+++ b/core/src/main/scala/scalapb/zio_grpc/transforms.scala
@@ -17,19 +17,25 @@ trait Transform {
   // Converts this Transform to ZTransform that transforms the effects like this, but
   // leaves the Context unchanged.
   def toZTransform[Context]: ZTransform[Context, Context] = new ZTransform[Context, Context] {
-    def effect[A](io: Context => ZIO[Any, StatusRuntimeException, A]): Context => ZIO[Any, StatusRuntimeException, A] = { c =>
+    def effect[A](
+        io: Context => ZIO[Any, StatusRuntimeException, A]
+    ): Context => ZIO[Any, StatusRuntimeException, A] = { c =>
       self.effect(io(c))
     }
 
-    def stream[A](io: Context => ZStream[Any, StatusRuntimeException, A]): Context => ZStream[Any, StatusRuntimeException, A] = { c =>
+    def stream[A](
+        io: Context => ZStream[Any, StatusRuntimeException, A]
+    ): Context => ZStream[Any, StatusRuntimeException, A] = { c =>
       self.stream(io(c))
     }
   }
 
   def andThen(other: Transform): Transform = new Transform {
-    def effect[A](io: ZIO[Any, StatusRuntimeException, A]): ZIO[Any, StatusRuntimeException, A] = other.effect(self.effect(io))
+    def effect[A](io: ZIO[Any, StatusRuntimeException, A]): ZIO[Any, StatusRuntimeException, A] =
+      other.effect(self.effect(io))
 
-    def stream[A](io: ZStream[Any, StatusRuntimeException, A]): ZStream[Any, StatusRuntimeException, A] = other.stream(self.stream(io))
+    def stream[A](io: ZStream[Any, StatusRuntimeException, A]): ZStream[Any, StatusRuntimeException, A] =
+      other.stream(self.stream(io))
   }
 }
 
@@ -37,7 +43,8 @@ object Transform {
   def fromZTransform(ct: ZTransform[Any, Any]) = new Transform {
     def effect[A](io: ZIO[Any, StatusRuntimeException, A]): ZIO[Any, StatusRuntimeException, A] = ct.effect(_ => io)(())
 
-    def stream[A](io: ZStream[Any, StatusRuntimeException, A]): ZStream[Any, StatusRuntimeException, A] = ct.stream(_ => io)(())
+    def stream[A](io: ZStream[Any, StatusRuntimeException, A]): ZStream[Any, StatusRuntimeException, A] =
+      ct.stream(_ => io)(())
   }
 }
 
@@ -48,32 +55,44 @@ object Transform {
   */
 trait ZTransform[+ContextIn, -ContextOut] {
   self =>
-  def effect[A](io: ContextIn => ZIO[Any, StatusRuntimeException, A]): (ContextOut => ZIO[Any, StatusRuntimeException, A])
-  def stream[A](io: ContextIn => ZStream[Any, StatusRuntimeException, A]): (ContextOut => ZStream[Any, StatusRuntimeException, A])
+  def effect[A](
+      io: ContextIn => ZIO[Any, StatusRuntimeException, A]
+  ): (ContextOut => ZIO[Any, StatusRuntimeException, A])
+  def stream[A](
+      io: ContextIn => ZStream[Any, StatusRuntimeException, A]
+  ): (ContextOut => ZStream[Any, StatusRuntimeException, A])
 
   def andThen[ContextIn2 <: ContextOut, ContextOut2](
       other: ZTransform[ContextIn2, ContextOut2]
   ): ZTransform[ContextIn, ContextOut2] = new ZTransform[ContextIn, ContextOut2] {
-    def effect[A](io: ContextIn => ZIO[Any, StatusRuntimeException, A]): ContextOut2 => ZIO[Any, StatusRuntimeException, A] =
+    def effect[A](
+        io: ContextIn => ZIO[Any, StatusRuntimeException, A]
+    ): ContextOut2 => ZIO[Any, StatusRuntimeException, A] =
       other.effect(self.effect(io))
 
-    def stream[A](io: ContextIn => ZStream[Any, StatusRuntimeException, A]): ContextOut2 => ZStream[Any, StatusRuntimeException, A] =
+    def stream[A](
+        io: ContextIn => ZStream[Any, StatusRuntimeException, A]
+    ): ContextOut2 => ZStream[Any, StatusRuntimeException, A] =
       other.stream(self.stream(io))
   }
 }
 
 object ZTransform {
   // Returns a ZTransform that effectfully transforms the context parameter
-  def apply[ContextIn, ContextOut](f: ContextOut => ZIO[Any, StatusRuntimeException, ContextIn]): ZTransform[ContextIn, ContextOut] =
+  def apply[ContextIn, ContextOut](
+      f: ContextOut => ZIO[Any, StatusRuntimeException, ContextIn]
+  ): ZTransform[ContextIn, ContextOut] =
     new ZTransform[ContextIn, ContextOut] {
-      def effect[A](io: ContextIn => ZIO[Any, StatusRuntimeException, A]): ContextOut => ZIO[Any, StatusRuntimeException, A] = {
-        (context: ContextOut) =>
-          f(context).flatMap(io)
+      def effect[A](
+          io: ContextIn => ZIO[Any, StatusRuntimeException, A]
+      ): ContextOut => ZIO[Any, StatusRuntimeException, A] = { (context: ContextOut) =>
+        f(context).flatMap(io)
       }
 
-      def stream[A](io: ContextIn => ZStream[Any, StatusRuntimeException, A]): ContextOut => ZStream[Any, StatusRuntimeException, A] = {
-        (context: ContextOut) =>
-          ZStream.fromZIO(f(context)).flatMap(io)
+      def stream[A](
+          io: ContextIn => ZStream[Any, StatusRuntimeException, A]
+      ): ContextOut => ZStream[Any, StatusRuntimeException, A] = { (context: ContextOut) =>
+        ZStream.fromZIO(f(context)).flatMap(io)
       }
     }
 }

--- a/core/src/main/scalajs/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajs/scalapb/zio_grpc/client/ClientCalls.scala
@@ -19,7 +19,7 @@ object ClientCalls {
         headers: SafeMetadata,
         req: Req
     ): IO[StatusRuntimeException, ResponseContext[Res]] =
-      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
+      ZIO.fail(new StatusRuntimeException(Status.INTERNAL.withDescription("Not supported")))
 
     def serverStreamingCall[Req, Res](
         channel: ZChannel,
@@ -28,7 +28,7 @@ object ClientCalls {
         headers: SafeMetadata,
         req: Req
     ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
-      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
+      ZStream.fail(new StatusRuntimeException(Status.INTERNAL.withDescription("Not supported")))
 
     def clientStreamingCall[Req, Res](
         channel: ZChannel,
@@ -37,7 +37,7 @@ object ClientCalls {
         headers: SafeMetadata,
         req: ZStream[Any, StatusRuntimeException, Req]
     ): IO[StatusRuntimeException, ResponseContext[Res]] =
-      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
+      ZIO.fail(new StatusRuntimeException(Status.INTERNAL.withDescription("Not supported")))
 
     def bidiCall[Req, Res](
         channel: ZChannel,
@@ -46,7 +46,7 @@ object ClientCalls {
         headers: SafeMetadata,
         req: ZStream[Any, StatusRuntimeException, Req]
     ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
-      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
+      ZStream.fail(new StatusRuntimeException(Status.INTERNAL.withDescription("Not supported")))
   }
 
   def unaryCall[Req, Res](
@@ -64,7 +64,7 @@ object ClientCalls {
         method.methodInfo,
         (errorInfo: ErrorInfo, resp: Res) =>
           if (errorInfo != null)
-            callback(ZIO.fail(Status.fromErrorInfo(errorInfo)))
+            callback(ZIO.fail(new StatusRuntimeException(Status.fromErrorInfo(errorInfo))))
           else callback(ZIO.succeed(resp))
       )
     }
@@ -93,7 +93,7 @@ object ClientCalls {
         .on(
           "error",
           { (ei: ErrorInfo) =>
-            val _ = cb(ZIO.fail(Some(Status.fromErrorInfo(ei))))
+            val _ = cb(ZIO.fail(Some(new StatusRuntimeException(Status.fromErrorInfo(ei)))))
           }
         )
         .on(
@@ -106,7 +106,7 @@ object ClientCalls {
           "status",
           (status: StatusInfo) =>
             if (status.code != 0)
-              cb(ZIO.fail(Some(Status.fromStatusInfo(status))))
+              cb(ZIO.fail(Some(new StatusRuntimeException(Status.fromStatusInfo(status)))))
         )
     }
 
@@ -117,7 +117,7 @@ object ClientCalls {
       headers: SafeMetadata,
       req: ZStream[Any, StatusRuntimeException, Req]
   ): ZIO[Any, StatusRuntimeException, Res] =
-    ZIO.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
+    ZIO.fail(new StatusRuntimeException(Status.INTERNAL.withDescription("Not supported")))
 
   def bidiCall[Req, Res](
       channel: ZChannel,
@@ -126,5 +126,5 @@ object ClientCalls {
       headers: SafeMetadata,
       req: ZStream[Any, StatusRuntimeException, Req]
   ): ZStream[Any, StatusRuntimeException, Res] =
-    ZStream.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
+    ZStream.fail(new StatusRuntimeException(Status.INTERNAL.withDescription("Not supported")))
 }

--- a/core/src/main/scalajs/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajs/scalapb/zio_grpc/client/ClientCalls.scala
@@ -5,10 +5,8 @@ import scalapb.zio_grpc.ResponseContext
 import scalapb.zio_grpc.ResponseFrame
 import scalapb.zio_grpc.SafeMetadata
 import scalapb.zio_grpc.ZChannel
-import io.grpc.MethodDescriptor
-import io.grpc.CallOptions
+import io.grpc.{CallOptions, MethodDescriptor, Status, StatusException}
 import scalapb.grpcweb.native.ErrorInfo
-import io.grpc.Status
 import zio.stream.ZStream
 import scalapb.grpcweb.native.StatusInfo
 
@@ -20,8 +18,8 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): IO[Status, ResponseContext[Res]] =
-      ZIO.fail(Status.INTERNAL.withDescription("Not supported"))
+    ): IO[StatusException, ResponseContext[Res]] =
+      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asException())
 
     def serverStreamingCall[Req, Res](
         channel: ZChannel,
@@ -29,26 +27,26 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): ZStream[Any, Status, ResponseFrame[Res]] =
-      ZStream.fail(Status.INTERNAL.withDescription("Not supported"))
+    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
+      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asException())
 
     def clientStreamingCall[Req, Res](
         channel: ZChannel,
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, Status, Req]
-    ): IO[Status, ResponseContext[Res]] =
-      ZIO.fail(Status.INTERNAL.withDescription("Not supported"))
+        req: ZStream[Any, StatusException, Req]
+    ): IO[StatusException, ResponseContext[Res]] =
+      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asException())
 
     def bidiCall[Req, Res](
         channel: ZChannel,
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, Status, Req]
-    ): ZStream[Any, Status, ResponseFrame[Res]] =
-      ZStream.fail(Status.INTERNAL.withDescription("Not supported"))
+        req: ZStream[Any, StatusException, Req]
+    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
+      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asException())
   }
 
   def unaryCall[Req, Res](
@@ -57,7 +55,7 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): IO[Status, Res] =
+  ): IO[StatusException, Res] =
     ZIO.async { callback =>
       channel.channel.client.rpcCall[Req, Res](
         channel.channel.baseUrl + "/" + method.fullName,
@@ -77,8 +75,8 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): ZStream[Any, Status, Res] =
-    ZStream.async[Any, Status, Res] { cb =>
+  ): ZStream[Any, StatusException, Res] =
+    ZStream.async[Any, StatusException, Res] { cb =>
       channel.channel.client
         .serverStreaming[Req, Res](
           channel.channel.baseUrl + "/" + method.fullName,
@@ -117,16 +115,16 @@ object ClientCalls {
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, Status, Req]
-  ): ZIO[Any, Status, Res] =
-    ZIO.fail(Status.INTERNAL.withDescription("Not supported"))
+      req: ZStream[Any, StatusException, Req]
+  ): ZIO[Any, StatusException, Res] =
+    ZIO.fail(Status.INTERNAL.withDescription("Not supported").asException())
 
   def bidiCall[Req, Res](
       channel: ZChannel,
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, Status, Req]
-  ): ZStream[Any, Status, Res] =
-    ZStream.fail(Status.INTERNAL.withDescription("Not supported"))
+      req: ZStream[Any, StatusException, Req]
+  ): ZStream[Any, StatusException, Res] =
+    ZStream.fail(Status.INTERNAL.withDescription("Not supported").asException())
 }

--- a/core/src/main/scalajs/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajs/scalapb/zio_grpc/client/ClientCalls.scala
@@ -5,7 +5,7 @@ import scalapb.zio_grpc.ResponseContext
 import scalapb.zio_grpc.ResponseFrame
 import scalapb.zio_grpc.SafeMetadata
 import scalapb.zio_grpc.ZChannel
-import io.grpc.{CallOptions, MethodDescriptor, Status, StatusException}
+import io.grpc.{CallOptions, MethodDescriptor, Status, StatusRuntimeException}
 import scalapb.grpcweb.native.ErrorInfo
 import zio.stream.ZStream
 import scalapb.grpcweb.native.StatusInfo
@@ -18,8 +18,8 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): IO[StatusException, ResponseContext[Res]] =
-      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asException())
+    ): IO[StatusRuntimeException, ResponseContext[Res]] =
+      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
 
     def serverStreamingCall[Req, Res](
         channel: ZChannel,
@@ -27,26 +27,26 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
-      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asException())
+    ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
+      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
 
     def clientStreamingCall[Req, Res](
         channel: ZChannel,
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, StatusException, Req]
-    ): IO[StatusException, ResponseContext[Res]] =
-      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asException())
+        req: ZStream[Any, StatusRuntimeException, Req]
+    ): IO[StatusRuntimeException, ResponseContext[Res]] =
+      ZIO.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
 
     def bidiCall[Req, Res](
         channel: ZChannel,
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, StatusException, Req]
-    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
-      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asException())
+        req: ZStream[Any, StatusRuntimeException, Req]
+    ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
+      ZStream.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
   }
 
   def unaryCall[Req, Res](
@@ -55,7 +55,7 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): IO[StatusException, Res] =
+  ): IO[StatusRuntimeException, Res] =
     ZIO.async { callback =>
       channel.channel.client.rpcCall[Req, Res](
         channel.channel.baseUrl + "/" + method.fullName,
@@ -75,8 +75,8 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): ZStream[Any, StatusException, Res] =
-    ZStream.async[Any, StatusException, Res] { cb =>
+  ): ZStream[Any, StatusRuntimeException, Res] =
+    ZStream.async[Any, StatusRuntimeException, Res] { cb =>
       channel.channel.client
         .serverStreaming[Req, Res](
           channel.channel.baseUrl + "/" + method.fullName,
@@ -115,16 +115,16 @@ object ClientCalls {
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, StatusException, Req]
-  ): ZIO[Any, StatusException, Res] =
-    ZIO.fail(Status.INTERNAL.withDescription("Not supported").asException())
+      req: ZStream[Any, StatusRuntimeException, Req]
+  ): ZIO[Any, StatusRuntimeException, Res] =
+    ZIO.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
 
   def bidiCall[Req, Res](
       channel: ZChannel,
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, StatusException, Req]
-  ): ZStream[Any, StatusException, Res] =
-    ZStream.fail(Status.INTERNAL.withDescription("Not supported").asException())
+      req: ZStream[Any, StatusRuntimeException, Req]
+  ): ZStream[Any, StatusRuntimeException, Res] =
+    ZStream.fail(Status.INTERNAL.withDescription("Not supported").asRuntimeException())
 }

--- a/core/src/main/scalajs/scalapb/zio_grpc/client/ZClientCall.scala
+++ b/core/src/main/scalajs/scalapb/zio_grpc/client/ZClientCall.scala
@@ -1,7 +1,7 @@
 package scalapb.zio_grpc.client
 
 import zio.IO
-import io.grpc.{Status, StatusException}
+import io.grpc.StatusRuntimeException
 import scalapb.zio_grpc.SafeMetadata
 
 trait ZClientCall[Req, Res] extends Any
@@ -11,6 +11,6 @@ object ZClientCall {
 
   def headersTransformer[Req, Res](
       clientCall: ZClientCall[Req, Res],
-      fetchHeaders: SafeMetadata => IO[StatusException, SafeMetadata]
+      fetchHeaders: SafeMetadata => IO[StatusRuntimeException, SafeMetadata]
   ) = ???
 }

--- a/core/src/main/scalajs/scalapb/zio_grpc/client/ZClientCall.scala
+++ b/core/src/main/scalajs/scalapb/zio_grpc/client/ZClientCall.scala
@@ -1,7 +1,7 @@
 package scalapb.zio_grpc.client
 
 import zio.IO
-import io.grpc.Status
+import io.grpc.{Status, StatusException}
 import scalapb.zio_grpc.SafeMetadata
 
 trait ZClientCall[Req, Res] extends Any
@@ -11,6 +11,6 @@ object ZClientCall {
 
   def headersTransformer[Req, Res](
       clientCall: ZClientCall[Req, Res],
-      fetchHeaders: SafeMetadata => IO[Status, SafeMetadata]
+      fetchHeaders: SafeMetadata => IO[StatusException, SafeMetadata]
   ) = ???
 }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc.client
 
-import io.grpc.{CallOptions, MethodDescriptor, Status}
+import io.grpc.{CallOptions, MethodDescriptor, StatusException}
 import scalapb.zio_grpc.{ResponseContext, ResponseFrame, SafeMetadata, ZChannel}
 import zio.stream.ZStream
 import zio.{Exit, IO, ZIO}
@@ -12,7 +12,7 @@ object ClientCalls {
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
         req: Req
-    ): IO[Status, ResponseContext[Res]] =
+    ): IO[StatusException, ResponseContext[Res]] =
       ZIO.acquireReleaseExitWith(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
         call.start(listener, headers) *>
           call.request(1) *>
@@ -27,7 +27,7 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): IO[Status, ResponseContext[Res]] =
+    ): IO[StatusException, ResponseContext[Res]] =
       channel
         .newCall(method, options)
         .flatMap(unaryCall(_, headers, req))
@@ -36,7 +36,7 @@ object ClientCalls {
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
         req: Req
-    ): ZStream[Any, Status, ResponseFrame[Res]] =
+    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
       ZStream
         .acquireReleaseExitWith(
           StreamingClientCallListener.make[Res](call)
@@ -58,7 +58,7 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): ZStream[Any, Status, ResponseFrame[Res]] =
+    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
       ZStream
         .fromZIO(channel.newCall(method, options))
         .flatMap(serverStreamingCall(_, headers, req))
@@ -66,8 +66,8 @@ object ClientCalls {
     private def clientStreamingCall[Req, Res](
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
-        req: ZStream[Any, Status, Req]
-    ): IO[Status, ResponseContext[Res]] =
+        req: ZStream[Any, StatusException, Req]
+    ): IO[StatusException, ResponseContext[Res]] =
       ZIO.acquireReleaseExitWith(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
         val callStream   = req.tap(call.sendMessage).drain ++ ZStream.fromZIO(call.halfClose()).drain
         val resultStream = ZStream.fromZIO(listener.getValue)
@@ -85,8 +85,8 @@ object ClientCalls {
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, Status, Req]
-    ): IO[Status, ResponseContext[Res]] =
+        req: ZStream[Any, StatusException, Req]
+    ): IO[StatusException, ResponseContext[Res]] =
       channel
         .newCall(method, options)
         .flatMap(
@@ -100,8 +100,8 @@ object ClientCalls {
     private def bidiCall[Req, Res](
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
-        req: ZStream[Any, Status, Req]
-    ): ZStream[Any, Status, ResponseFrame[Res]] =
+        req: ZStream[Any, StatusException, Req]
+    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
       ZStream
         .acquireReleaseExitWith(
           StreamingClientCallListener.make[Res](call)
@@ -123,8 +123,8 @@ object ClientCalls {
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, Status, Req]
-    ): ZStream[Any, Status, ResponseFrame[Res]] =
+        req: ZStream[Any, StatusException, Req]
+    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
       ZStream
         .fromZIO(
           channel.newCall(method, options)
@@ -134,7 +134,7 @@ object ClientCalls {
 
   def exitHandler[Req, Res](
       call: ZClientCall[Req, Res]
-  )(l: Any, ex: Exit[Status, Any]) = anyExitHandler(call)(l, ex)
+  )(l: Any, ex: Exit[StatusException, Any]) = anyExitHandler(call)(l, ex)
 
   // less type safe
   def anyExitHandler[Req, Res](
@@ -151,7 +151,7 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): IO[Status, Res] =
+  ): IO[StatusException, Res] =
     withMetadata.unaryCall(channel, method, options, headers, req).map(_.response)
 
   def serverStreamingCall[Req, Res](
@@ -160,7 +160,7 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): ZStream[Any, Status, Res] =
+  ): ZStream[Any, StatusException, Res] =
     withMetadata
       .serverStreamingCall(channel, method, options, headers, req)
       .collect { case ResponseFrame.Message(x) => x }
@@ -170,8 +170,8 @@ object ClientCalls {
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, Status, Req]
-  ): IO[Status, Res] =
+      req: ZStream[Any, StatusException, Req]
+  ): IO[StatusException, Res] =
     withMetadata.clientStreamingCall(channel, method, options, headers, req).map(_.response)
 
   def bidiCall[Req, Res](
@@ -179,8 +179,8 @@ object ClientCalls {
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, Status, Req]
-  ): ZStream[Any, Status, Res] =
+      req: ZStream[Any, StatusException, Req]
+  ): ZStream[Any, StatusException, Res] =
     withMetadata
       .bidiCall(channel, method, options, headers, req)
       .collect { case ResponseFrame.Message(x) => x }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc.client
 
-import io.grpc.{CallOptions, MethodDescriptor, StatusException}
+import io.grpc.{CallOptions, MethodDescriptor, StatusRuntimeException}
 import scalapb.zio_grpc.{ResponseContext, ResponseFrame, SafeMetadata, ZChannel}
 import zio.stream.ZStream
 import zio.{Exit, IO, ZIO}
@@ -12,7 +12,7 @@ object ClientCalls {
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
         req: Req
-    ): IO[StatusException, ResponseContext[Res]] =
+    ): IO[StatusRuntimeException, ResponseContext[Res]] =
       ZIO.acquireReleaseExitWith(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
         call.start(listener, headers) *>
           call.request(1) *>
@@ -27,7 +27,7 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): IO[StatusException, ResponseContext[Res]] =
+    ): IO[StatusRuntimeException, ResponseContext[Res]] =
       channel
         .newCall(method, options)
         .flatMap(unaryCall(_, headers, req))
@@ -36,7 +36,7 @@ object ClientCalls {
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
         req: Req
-    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
+    ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
       ZStream
         .acquireReleaseExitWith(
           StreamingClientCallListener.make[Res](call)
@@ -58,7 +58,7 @@ object ClientCalls {
         options: CallOptions,
         headers: SafeMetadata,
         req: Req
-    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
+    ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
       ZStream
         .fromZIO(channel.newCall(method, options))
         .flatMap(serverStreamingCall(_, headers, req))
@@ -66,8 +66,8 @@ object ClientCalls {
     private def clientStreamingCall[Req, Res](
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
-        req: ZStream[Any, StatusException, Req]
-    ): IO[StatusException, ResponseContext[Res]] =
+        req: ZStream[Any, StatusRuntimeException, Req]
+    ): IO[StatusRuntimeException, ResponseContext[Res]] =
       ZIO.acquireReleaseExitWith(UnaryClientCallListener.make[Res])(exitHandler(call)) { listener =>
         val callStream   = req.tap(call.sendMessage).drain ++ ZStream.fromZIO(call.halfClose()).drain
         val resultStream = ZStream.fromZIO(listener.getValue)
@@ -85,8 +85,8 @@ object ClientCalls {
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, StatusException, Req]
-    ): IO[StatusException, ResponseContext[Res]] =
+        req: ZStream[Any, StatusRuntimeException, Req]
+    ): IO[StatusRuntimeException, ResponseContext[Res]] =
       channel
         .newCall(method, options)
         .flatMap(
@@ -100,8 +100,8 @@ object ClientCalls {
     private def bidiCall[Req, Res](
         call: ZClientCall[Req, Res],
         headers: SafeMetadata,
-        req: ZStream[Any, StatusException, Req]
-    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
+        req: ZStream[Any, StatusRuntimeException, Req]
+    ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
       ZStream
         .acquireReleaseExitWith(
           StreamingClientCallListener.make[Res](call)
@@ -123,8 +123,8 @@ object ClientCalls {
         method: MethodDescriptor[Req, Res],
         options: CallOptions,
         headers: SafeMetadata,
-        req: ZStream[Any, StatusException, Req]
-    ): ZStream[Any, StatusException, ResponseFrame[Res]] =
+        req: ZStream[Any, StatusRuntimeException, Req]
+    ): ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
       ZStream
         .fromZIO(
           channel.newCall(method, options)
@@ -134,7 +134,7 @@ object ClientCalls {
 
   def exitHandler[Req, Res](
       call: ZClientCall[Req, Res]
-  )(l: Any, ex: Exit[StatusException, Any]) = anyExitHandler(call)(l, ex)
+  )(l: Any, ex: Exit[StatusRuntimeException, Any]) = anyExitHandler(call)(l, ex)
 
   // less type safe
   def anyExitHandler[Req, Res](
@@ -151,7 +151,7 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): IO[StatusException, Res] =
+  ): IO[StatusRuntimeException, Res] =
     withMetadata.unaryCall(channel, method, options, headers, req).map(_.response)
 
   def serverStreamingCall[Req, Res](
@@ -160,7 +160,7 @@ object ClientCalls {
       options: CallOptions,
       headers: SafeMetadata,
       req: Req
-  ): ZStream[Any, StatusException, Res] =
+  ): ZStream[Any, StatusRuntimeException, Res] =
     withMetadata
       .serverStreamingCall(channel, method, options, headers, req)
       .collect { case ResponseFrame.Message(x) => x }
@@ -170,8 +170,8 @@ object ClientCalls {
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, StatusException, Req]
-  ): IO[StatusException, Res] =
+      req: ZStream[Any, StatusRuntimeException, Req]
+  ): IO[StatusRuntimeException, Res] =
     withMetadata.clientStreamingCall(channel, method, options, headers, req).map(_.response)
 
   def bidiCall[Req, Res](
@@ -179,8 +179,8 @@ object ClientCalls {
       method: MethodDescriptor[Req, Res],
       options: CallOptions,
       headers: SafeMetadata,
-      req: ZStream[Any, StatusException, Req]
-  ): ZStream[Any, StatusException, Res] =
+      req: ZStream[Any, StatusRuntimeException, Req]
+  ): ZStream[Any, StatusRuntimeException, Res] =
     withMetadata
       .bidiCall(channel, method, options, headers, req)
       .collect { case ResponseFrame.Message(x) => x }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
@@ -36,8 +36,9 @@ class StreamingClientCallListener[Res](
     ZStream
       .fromQueue(queue)
       .tap {
-        case ResponseFrame.Trailers(status, trailers) => queue.shutdown *> ZIO.when(!status.isOk)(ZIO.fail(new StatusException(status, trailers)))
-        case _                                 => ZIO.unit
+        case ResponseFrame.Trailers(status, trailers) =>
+          queue.shutdown *> ZIO.when(!status.isOk)(ZIO.fail(new StatusException(status, trailers)))
+        case _                                        => ZIO.unit
       }
 }
 

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/StreamingClientCallListener.scala
@@ -1,7 +1,7 @@
 package scalapb.zio_grpc.client
 
 import scalapb.zio_grpc.ResponseFrame
-import io.grpc.{ClientCall, Metadata, Status, StatusException}
+import io.grpc.{ClientCall, Metadata, Status, StatusRuntimeException}
 import zio.stream.ZStream
 import zio._
 
@@ -32,12 +32,12 @@ class StreamingClientCallListener[Res](
       runtime.unsafe.run(queue.offer(ResponseFrame.Trailers(status, trailers)).unit).getOrThrowFiberFailure()
     }
 
-  def stream: ZStream[Any, StatusException, ResponseFrame[Res]] =
+  def stream: ZStream[Any, StatusRuntimeException, ResponseFrame[Res]] =
     ZStream
       .fromQueue(queue)
       .tap {
         case ResponseFrame.Trailers(status, trailers) =>
-          queue.shutdown *> ZIO.when(!status.isOk)(ZIO.fail(new StatusException(status, trailers)))
+          queue.shutdown *> ZIO.when(!status.isOk)(ZIO.fail(new StatusRuntimeException(status, trailers)))
         case _                                        => ZIO.unit
       }
 }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/UnaryClientCallListener.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/UnaryClientCallListener.scala
@@ -1,8 +1,7 @@
 package scalapb.zio_grpc.client
 
 import zio.{IO, Promise, Ref, Runtime, Unsafe}
-import io.grpc.ClientCall
-import io.grpc.{Metadata, Status}
+import io.grpc.{ClientCall, Metadata, Status, StatusException}
 import UnaryCallState._
 import scalapb.zio_grpc.ResponseContext
 
@@ -21,7 +20,7 @@ object UnaryCallState {
 class UnaryClientCallListener[Res](
     runtime: Runtime[Any],
     state: Ref[UnaryCallState[Res]],
-    promise: Promise[Status, ResponseContext[Res]]
+    promise: Promise[StatusException, ResponseContext[Res]]
 ) extends ClientCall.Listener[Res] {
 
   override def onHeaders(headers: Metadata): Unit =
@@ -59,16 +58,18 @@ class UnaryClientCallListener[Res](
         .run {
           for {
             s <- state.get
-            _ <- if (!status.isOk) promise.fail(status)
+            _ <- if (!status.isOk) promise.fail(new StatusException(status, trailers))
                  else
                    s match {
                      case ResponseReceived(headers, message) =>
                        promise.succeed(ResponseContext(headers, message, trailers))
                      case Failure(errorMessage)              =>
-                       promise.fail(Status.INTERNAL.withDescription(errorMessage))
+                       promise.fail(
+                         Status.INTERNAL.withDescription(errorMessage).asException()
+                       )
                      case _                                  =>
                        promise.fail(
-                         Status.INTERNAL.withDescription("No data received")
+                         Status.INTERNAL.withDescription("No data received").asException()
                        )
                    }
           } yield ()
@@ -76,7 +77,7 @@ class UnaryClientCallListener[Res](
         .getOrThrowFiberFailure()
     }
 
-  def getValue: IO[Status, ResponseContext[Res]] = promise.await
+  def getValue: IO[StatusException, ResponseContext[Res]] = promise.await
 }
 
 object UnaryClientCallListener {
@@ -84,6 +85,6 @@ object UnaryClientCallListener {
     for {
       runtime <- zio.ZIO.runtime[Any]
       state   <- Ref.make[UnaryCallState[Res]](Initial)
-      promise <- Promise.make[Status, ResponseContext[Res]]
+      promise <- Promise.make[StatusException, ResponseContext[Res]]
     } yield new UnaryClientCallListener[Res](runtime, state, promise)
 }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ZClientCall.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ZClientCall.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc.client
 
-import io.grpc.{ClientCall, StatusException}
+import io.grpc.{ClientCall, StatusRuntimeException}
 import io.grpc.ClientCall.Listener
 import scalapb.zio_grpc.GIO
 import zio.IO
@@ -11,15 +11,15 @@ trait ZClientCall[Req, Res] extends Any {
   def start(
       responseListener: Listener[Res],
       headers: SafeMetadata
-  ): IO[StatusException, Unit]
+  ): IO[StatusRuntimeException, Unit]
 
-  def request(numMessages: Int): IO[StatusException, Unit]
+  def request(numMessages: Int): IO[StatusRuntimeException, Unit]
 
-  def cancel(message: String): IO[StatusException, Unit]
+  def cancel(message: String): IO[StatusRuntimeException, Unit]
 
-  def halfClose(): IO[StatusException, Unit]
+  def halfClose(): IO[StatusRuntimeException, Unit]
 
-  def sendMessage(message: Req): IO[StatusException, Unit]
+  def sendMessage(message: Req): IO[StatusRuntimeException, Unit]
 }
 
 class ZClientCallImpl[Req, Res](private val call: ClientCall[Req, Res]) extends AnyVal with ZClientCall[Req, Res] {
@@ -48,29 +48,29 @@ object ZClientCall {
     override def start(
         responseListener: Listener[Res],
         headers: SafeMetadata
-    ): IO[StatusException, Unit] = delegate.start(responseListener, headers)
+    ): IO[StatusRuntimeException, Unit] = delegate.start(responseListener, headers)
 
-    override def request(numMessages: Int): IO[StatusException, Unit] =
+    override def request(numMessages: Int): IO[StatusRuntimeException, Unit] =
       delegate.request(numMessages)
 
-    override def cancel(message: String): IO[StatusException, Unit] =
+    override def cancel(message: String): IO[StatusRuntimeException, Unit] =
       delegate.cancel(message)
 
-    override def halfClose(): IO[StatusException, Unit] = delegate.halfClose()
+    override def halfClose(): IO[StatusRuntimeException, Unit] = delegate.halfClose()
 
-    override def sendMessage(message: Req): IO[StatusException, Unit] =
+    override def sendMessage(message: Req): IO[StatusRuntimeException, Unit] =
       delegate.sendMessage(message)
   }
 
   def headersTransformer[Req, Res](
       clientCall: ZClientCall[Req, Res],
-      updateHeaders: SafeMetadata => IO[StatusException, SafeMetadata]
+      updateHeaders: SafeMetadata => IO[StatusRuntimeException, SafeMetadata]
   ): ZClientCall[Req, Res] =
     new ForwardingZClientCall[Req, Res](clientCall) {
       override def start(
           responseListener: Listener[Res],
           headers: SafeMetadata
-      ): IO[StatusException, Unit] =
+      ): IO[StatusRuntimeException, Unit] =
         updateHeaders(headers) flatMap { h => delegate.start(responseListener, h) }
     }
 }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ListenerDriver.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ListenerDriver.scala
@@ -1,18 +1,17 @@
 package scalapb.zio_grpc.server
 
 import io.grpc.ServerCall.Listener
-import io.grpc.Status
+import io.grpc.{Metadata, Status, StatusException}
 import zio._
 import zio.stream.{Stream, ZStream}
 import scalapb.zio_grpc.RequestContext
-import io.grpc.Metadata
 
 object ListenerDriver {
-  def exitToStatus(ex: Exit[Status, Unit]): Status =
+  def exitToStatus(ex: Exit[StatusException, Unit]): Status =
     ex.foldExit(
       failed = { cause =>
         if (cause.isInterruptedOnly) Status.CANCELLED
-        else cause.failureOption.getOrElse(Status.INTERNAL)
+        else cause.failureOption.map(_.getStatus).getOrElse(Status.INTERNAL)
       },
       completed = _ => Status.OK
     )
@@ -20,10 +19,10 @@ object ListenerDriver {
   def unaryInputListener[Req](
       runtime: Runtime[Any],
       call: ZServerCall[_],
-      completed: Promise[Status, Unit],
+      completed: Promise[StatusException, Unit],
       request: Promise[Nothing, Req],
       requestContext: RequestContext,
-      writeResponse: Req => ZIO[Any, Status, Unit]
+      writeResponse: Req => ZIO[Any, StatusException, Unit]
   ): ZIO[Any, Nothing, Listener[Req]] =
     (
       call.request(2) *>
@@ -56,7 +55,7 @@ object ListenerDriver {
                   request.succeed(message).flatMap {
                     case false =>
                       completed
-                        .fail(Status.INTERNAL.withDescription("Too many requests"))
+                        .fail(Status.INTERNAL.withDescription("Too many requests").asException())
                         .unit
                     case true  =>
                       ZIO.unit
@@ -83,14 +82,14 @@ object ListenerDriver {
           Req,
           RequestContext,
           ZServerCall[Res]
-      ) => ZIO[Any, Status, Unit],
+      ) => ZIO[Any, StatusException, Unit],
       runtime: Runtime[Any]
   )(
       zioCall: ZServerCall[Res],
       requestContext: RequestContext
   ): ZIO[Any, Nothing, Listener[Req]] =
     for {
-      completed <- Promise.make[Status, Unit]
+      completed <- Promise.make[StatusException, Unit]
       request   <- Promise.make[Nothing, Req]
       listener  <- unaryInputListener(
                      runtime,
@@ -107,7 +106,7 @@ object ListenerDriver {
       call: ZServerCall[Res],
       queue: Queue[Option[Req]],
       requestContext: RequestContext,
-      writeResponse: Stream[Status, Req] => ZIO[Any, Status, Unit]
+      writeResponse: Stream[StatusException, Req] => ZIO[Any, StatusException, Unit]
   ): ZIO[Any, Nothing, Listener[Req]] = {
     val requestStream = ZStream
       .fromQueue(queue)
@@ -156,10 +155,10 @@ object ListenerDriver {
     */
   def makeStreamingInputListener[Req, Res](
       writeResponse: (
-          Stream[Status, Req],
+          Stream[StatusException, Req],
           RequestContext,
           ZServerCall[Res]
-      ) => ZIO[Any, Status, Unit]
+      ) => ZIO[Any, StatusException, Unit]
   )(
       zioCall: ZServerCall[Res],
       requestContext: RequestContext

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -73,7 +73,8 @@ object ZServerCallHandler {
   ): ServerCallHandler[Req, Res] =
     unaryInput[Req, Res](
       runtime,
-      (req, requestContext, call) => impl(req, requestContext).flatMap[Any, StatusRuntimeException, Unit](call.sendMessage)
+      (req, requestContext, call) =>
+        impl(req, requestContext).flatMap[Any, StatusRuntimeException, Unit](call.sendMessage)
     )
 
   def serverStreamingCallHandler[Req, Res](
@@ -92,7 +93,8 @@ object ZServerCallHandler {
   ): ServerCallHandler[Req, Res] =
     streamingInput[Req, Res](
       runtime,
-      (req, requestContext, call) => impl(req, requestContext).flatMap[Any, StatusRuntimeException, Unit](call.sendMessage)
+      (req, requestContext, call) =>
+        impl(req, requestContext).flatMap[Any, StatusRuntimeException, Unit](call.sendMessage)
     )
 
   def bidiCallHandler[Req, Res](
@@ -108,7 +110,9 @@ object ZServerCallHandler {
       call: ZServerCall[Res],
       stream: ZStream[Any, StatusRuntimeException, Res]
   ): ZIO[Any, StatusRuntimeException, Unit] = {
-    def takeFromQueue(queue: Dequeue[Exit[Option[StatusRuntimeException], Res]]): ZIO[Any, StatusRuntimeException, Unit] =
+    def takeFromQueue(
+        queue: Dequeue[Exit[Option[StatusRuntimeException], Res]]
+    ): ZIO[Any, StatusRuntimeException, Unit] =
       queue.takeAll.flatMap(takeFromCache(_, queue))
 
     def takeFromCache(

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -2,7 +2,7 @@ package scalapb.zio_grpc.server
 
 import zio._
 import io.grpc.ServerCall.Listener
-import io.grpc.Status
+import io.grpc.{Status, StatusException}
 import zio.stream.Stream
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
@@ -40,27 +40,27 @@ class ZServerCallHandler[Req, Res](
 object ZServerCallHandler {
   private[zio_grpc] val queueSizeProp = "zio-grpc.backpressure-queue-size"
 
-  val backpressureQueueSize: IO[Status, Int] =
+  val backpressureQueueSize: IO[StatusException, Int] =
     ZIO
       .attempt(sys.props.get(queueSizeProp).map(_.toInt).getOrElse(16))
       .refineToOrDie[NumberFormatException]
       .catchAll { t =>
-        ZIO.fail(Status.INTERNAL.withDescription(s"$queueSizeProp: ${t.getMessage}"))
+        ZIO.fail(Status.INTERNAL.withDescription(s"$queueSizeProp: ${t.getMessage}").asException())
       }
 
   def unaryInput[Req, Res](
       runtime: Runtime[Any],
-      impl: (Req, RequestContext, ZServerCall[Res]) => ZIO[Any, Status, Unit]
+      impl: (Req, RequestContext, ZServerCall[Res]) => ZIO[Any, StatusException, Unit]
   ): ServerCallHandler[Req, Res] =
     new ZServerCallHandler(runtime, ListenerDriver.makeUnaryInputListener(impl, runtime))
 
   def streamingInput[Req, Res](
       runtime: Runtime[Any],
       impl: (
-          Stream[Status, Req],
+          Stream[StatusException, Req],
           RequestContext,
           ZServerCall[Res]
-      ) => ZIO[Any, Status, Unit]
+      ) => ZIO[Any, StatusException, Unit]
   ): ServerCallHandler[Req, Res] =
     new ZServerCallHandler(
       runtime,
@@ -69,16 +69,16 @@ object ZServerCallHandler {
 
   def unaryCallHandler[Req, Res](
       runtime: Runtime[Any],
-      impl: (Req, RequestContext) => ZIO[Any, Status, Res]
+      impl: (Req, RequestContext) => ZIO[Any, StatusException, Res]
   ): ServerCallHandler[Req, Res] =
     unaryInput[Req, Res](
       runtime,
-      (req, requestContext, call) => impl(req, requestContext).flatMap[Any, Status, Unit](call.sendMessage)
+      (req, requestContext, call) => impl(req, requestContext).flatMap[Any, StatusException, Unit](call.sendMessage)
     )
 
   def serverStreamingCallHandler[Req, Res](
       runtime: Runtime[Any],
-      impl: (Req, RequestContext) => ZStream[Any, Status, Res]
+      impl: (Req, RequestContext) => ZStream[Any, StatusException, Res]
   ): ServerCallHandler[Req, Res] =
     unaryInput[Req, Res](
       runtime,
@@ -88,16 +88,16 @@ object ZServerCallHandler {
 
   def clientStreamingCallHandler[Req, Res](
       runtime: Runtime[Any],
-      impl: (Stream[Status, Req], RequestContext) => ZIO[Any, Status, Res]
+      impl: (Stream[StatusException, Req], RequestContext) => ZIO[Any, StatusException, Res]
   ): ServerCallHandler[Req, Res] =
     streamingInput[Req, Res](
       runtime,
-      (req, requestContext, call) => impl(req, requestContext).flatMap[Any, Status, Unit](call.sendMessage)
+      (req, requestContext, call) => impl(req, requestContext).flatMap[Any, StatusException, Unit](call.sendMessage)
     )
 
   def bidiCallHandler[Req, Res](
       runtime: Runtime[Any],
-      impl: (Stream[Status, Req], RequestContext) => ZStream[Any, Status, Res]
+      impl: (Stream[Status, Req], RequestContext) => ZStream[Any, StatusException, Res]
   ): ServerCallHandler[Req, Res] =
     streamingInput[Req, Res](
       runtime,
@@ -106,17 +106,17 @@ object ZServerCallHandler {
 
   def serverStreamingWithBackpressure[Res](
       call: ZServerCall[Res],
-      stream: ZStream[Any, Status, Res]
-  ): ZIO[Any, Status, Unit] = {
-    def takeFromQueue(queue: Dequeue[Exit[Option[Status], Res]]): ZIO[Any, Status, Unit] =
+      stream: ZStream[Any, StatusException, Res]
+  ): ZIO[Any, StatusException, Unit] = {
+    def takeFromQueue(queue: Dequeue[Exit[Option[StatusException], Res]]): ZIO[Any, StatusException, Unit] =
       queue.takeAll.flatMap(takeFromCache(_, queue))
 
     def takeFromCache(
-        xs: Chunk[Exit[Option[Status], Res]],
-        queue: Dequeue[Exit[Option[Status], Res]]
-    ): ZIO[Any, Status, Unit] =
+        xs: Chunk[Exit[Option[StatusException], Res]],
+        queue: Dequeue[Exit[Option[StatusException], Res]]
+    ): ZIO[Any, StatusException, Unit] =
       ZIO.suspendSucceed {
-        @tailrec def innerLoop(loop: Boolean, i: Int): IO[Status, Unit] =
+        @tailrec def innerLoop(loop: Boolean, i: Int): IO[StatusException, Unit] =
           if (i < xs.length && loop) {
             xs(i) match {
               case Failure(cause) =>

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -97,7 +97,7 @@ object ZServerCallHandler {
 
   def bidiCallHandler[Req, Res](
       runtime: Runtime[Any],
-      impl: (Stream[Status, Req], RequestContext) => ZStream[Any, StatusException, Res]
+      impl: (Stream[StatusException, Req], RequestContext) => ZStream[Any, StatusException, Res]
   ): ServerCallHandler[Req, Res] =
     streamingInput[Req, Res](
       runtime,

--- a/e2e/src/it/scala/scalapb/zio_grpc/BackpressureSpec.scala
+++ b/e2e/src/it/scala/scalapb/zio_grpc/BackpressureSpec.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc
 
-import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import io.grpc.inprocess.InProcessServerBuilder
 import scalapb.zio_grpc.testservice.Request
 import scalapb.zio_grpc.testservice.Response
@@ -31,15 +31,15 @@ object BackpressureSpec extends ZIOSpecDefault {
       new ZioTestservice.TestService {
         val responses = ZStream.iterate(0)(_ + 1).map(i => Response(i.toString)).take(100)
 
-        def bidiStreaming(request: zio.stream.Stream[StatusException, Request]): ZStream[Any with Any, StatusException, Response] =
+        def bidiStreaming(request: zio.stream.Stream[StatusRuntimeException, Request]): ZStream[Any with Any, StatusRuntimeException, Response] =
           request.drain ++ responses
 
-        def serverStreaming(request: Request): ZStream[Any with Any, StatusException, Response] =
+        def serverStreaming(request: Request): ZStream[Any with Any, StatusRuntimeException, Response] =
           responses
 
-        def clientStreaming(request: zio.stream.Stream[StatusException, Request]): ZIO[Any with Any, StatusException, Response] = ???
+        def clientStreaming(request: zio.stream.Stream[StatusRuntimeException, Request]): ZIO[Any with Any, StatusRuntimeException, Response] = ???
 
-        def unary(request: Request): ZIO[Any with Any, StatusException, Response] = ???
+        def unary(request: Request): ZIO[Any with Any, StatusRuntimeException, Response] = ???
       }
     }
 

--- a/e2e/src/it/scala/scalapb/zio_grpc/BackpressureSpec.scala
+++ b/e2e/src/it/scala/scalapb/zio_grpc/BackpressureSpec.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc
 
-import io.grpc.Status
+import io.grpc.StatusException
 import io.grpc.inprocess.InProcessServerBuilder
 import scalapb.zio_grpc.testservice.Request
 import scalapb.zio_grpc.testservice.Response
@@ -31,15 +31,15 @@ object BackpressureSpec extends ZIOSpecDefault {
       new ZioTestservice.TestService {
         val responses = ZStream.iterate(0)(_ + 1).map(i => Response(i.toString)).take(100)
 
-        def bidiStreaming(request: zio.stream.Stream[Status, Request]): ZStream[Any with Any, Status, Response] =
+        def bidiStreaming(request: zio.stream.Stream[StatusException, Request]): ZStream[Any with Any, StatusException, Response] =
           request.drain ++ responses
 
-        def serverStreaming(request: Request): ZStream[Any with Any, Status, Response] =
+        def serverStreaming(request: Request): ZStream[Any with Any, StatusException, Response] =
           responses
 
-        def clientStreaming(request: zio.stream.Stream[Status, Request]): ZIO[Any with Any, Status, Response] = ???
+        def clientStreaming(request: zio.stream.Stream[StatusException, Request]): ZIO[Any with Any, StatusException, Response] = ???
 
-        def unary(request: Request): ZIO[Any with Any, Status, Response] = ???
+        def unary(request: Request): ZIO[Any with Any, StatusException, Response] = ???
       }
     }
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
@@ -27,7 +27,7 @@ object BindableServiceSpec extends ZIOSpecDefault {
     override def bidiStreaming(
         request: zio.stream.Stream[StatusException, Request],
         context: C
-    ): ZStream[Status, StatusException, Response] = ???
+    ): Stream[StatusException, Response] = ???
 
   }
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
@@ -22,7 +22,10 @@ object BindableServiceSpec extends ZIOSpecDefault {
 
     override def serverStreaming(request: Request, context: C): Stream[StatusRuntimeException, Response] = ???
 
-    override def clientStreaming(request: Stream[StatusRuntimeException, Request], context: C): IO[StatusRuntimeException, Response] = ???
+    override def clientStreaming(
+        request: Stream[StatusRuntimeException, Request],
+        context: C
+    ): IO[StatusRuntimeException, Response] = ???
 
     override def bidiStreaming(
         request: zio.stream.Stream[StatusRuntimeException, Request],

--- a/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
@@ -3,7 +3,7 @@ package scalapb.zio_grpc
 import scalapb.zio_grpc.testservice.ZioTestservice.TestService
 import scalapb.zio_grpc.testservice.ZioTestservice.ZTestService
 import zio.ZIO
-import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import scalapb.zio_grpc.testservice.{Request, Response}
 import io.grpc.ServerBuilder
 import zio.test._
@@ -18,16 +18,16 @@ object BindableServiceSpec extends ZIOSpecDefault {
 
   class UnimpTestService[C] extends ZTestService[C] {
 
-    override def unary(request: Request, context: C): IO[StatusException, Response] = ???
+    override def unary(request: Request, context: C): IO[StatusRuntimeException, Response] = ???
 
-    override def serverStreaming(request: Request, context: C): Stream[StatusException, Response] = ???
+    override def serverStreaming(request: Request, context: C): Stream[StatusRuntimeException, Response] = ???
 
-    override def clientStreaming(request: Stream[StatusException, Request], context: C): IO[StatusException, Response] = ???
+    override def clientStreaming(request: Stream[StatusRuntimeException, Request], context: C): IO[StatusRuntimeException, Response] = ???
 
     override def bidiStreaming(
-        request: zio.stream.Stream[StatusException, Request],
+        request: zio.stream.Stream[StatusRuntimeException, Request],
         context: C
-    ): Stream[StatusException, Response] = ???
+    ): Stream[StatusRuntimeException, Response] = ???
 
   }
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
@@ -3,11 +3,12 @@ package scalapb.zio_grpc
 import scalapb.zio_grpc.testservice.ZioTestservice.TestService
 import scalapb.zio_grpc.testservice.ZioTestservice.ZTestService
 import zio.ZIO
-import io.grpc.Status
+import io.grpc.StatusException
 import scalapb.zio_grpc.testservice.{Request, Response}
 import io.grpc.ServerBuilder
 import zio.test._
 import zio.IO
+import zio.stream.Stream
 
 object BindableServiceSpec extends ZIOSpecDefault {
   implicitly[ZBindableService[ZTestService[RequestContext]]]
@@ -17,16 +18,16 @@ object BindableServiceSpec extends ZIOSpecDefault {
 
   class UnimpTestService[C] extends ZTestService[C] {
 
-    override def unary(request: Request, context: C): IO[Status, Response] = ???
+    override def unary(request: Request, context: C): IO[StatusException, Response] = ???
 
-    override def serverStreaming(request: Request, context: C): zio.stream.Stream[Status, Response] = ???
+    override def serverStreaming(request: Request, context: C): Stream[StatusException, Response] = ???
 
-    override def clientStreaming(request: zio.stream.Stream[Status, Request], context: C): IO[Status, Response] = ???
+    override def clientStreaming(request: Stream[StatusException, Request], context: C): IO[StatusException, Response] = ???
 
     override def bidiStreaming(
         request: zio.stream.Stream[Status, Request],
         context: C
-    ): zio.stream.Stream[Status, Response] = ???
+    ): ZStream[Status, StatusException, Response] = ???
 
   }
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/BindableServiceSpec.scala
@@ -25,7 +25,7 @@ object BindableServiceSpec extends ZIOSpecDefault {
     override def clientStreaming(request: Stream[StatusException, Request], context: C): IO[StatusException, Response] = ???
 
     override def bidiStreaming(
-        request: zio.stream.Stream[Status, Request],
+        request: zio.stream.Stream[StatusException, Request],
         context: C
     ): ZStream[Status, StatusException, Response] = ???
 

--- a/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
@@ -28,17 +28,17 @@ object EnvSpec extends ZIOSpecDefault with MetadataTests {
         context: Context
     ): ZStream[Any, StatusRuntimeException, Response] =
       ZStream
-          .fromZIO(
-            for {
-              _ <- context.response.put(RequestIdKey, "1")
-              _ <- ZIO.fail(Status.FAILED_PRECONDITION.asRuntimeException()).when(context.user.name == "Eve")
-            } yield ()
-          )
-          .drain ++
-          ZStream(
-            Response(context.user.name),
-            Response(context.user.name)
-          )
+        .fromZIO(
+          for {
+            _ <- context.response.put(RequestIdKey, "1")
+            _ <- ZIO.fail(Status.FAILED_PRECONDITION.asRuntimeException()).when(context.user.name == "Eve")
+          } yield ()
+        )
+        .drain ++
+        ZStream(
+          Response(context.user.name),
+          Response(context.user.name)
+        )
 
     def clientStreaming(
         request: ZStream[Any, StatusRuntimeException, Request],
@@ -53,12 +53,14 @@ object EnvSpec extends ZIOSpecDefault with MetadataTests {
         request: ZStream[Any, StatusRuntimeException, Request],
         context: Context
     ): ZStream[Any, StatusRuntimeException, Response] =
-        ZStream.fromZIO(
+      ZStream
+        .fromZIO(
           for {
             _ <- context.response.put(RequestIdKey, "1")
             _ <- ZIO.fail(Status.FAILED_PRECONDITION.asRuntimeException()).when(context.user.name == "Eve")
           } yield ()
-        ).drain ++ ZStream(Response(context.user.name))
+        )
+        .drain ++ ZStream(Response(context.user.name))
   }
 
   val UserKey =

--- a/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/EnvSpec.scala
@@ -8,7 +8,7 @@ import testservice._
 import io.grpc.ServerBuilder
 import io.grpc.Metadata
 import io.grpc.ManagedChannelBuilder
-import io.grpc.{Status, StatusException}
+import io.grpc.{Status, StatusRuntimeException}
 import zio.stream.ZStream
 
 object EnvSpec extends ZIOSpecDefault with MetadataTests {
@@ -17,21 +17,21 @@ object EnvSpec extends ZIOSpecDefault with MetadataTests {
   case class Context(user: User, response: SafeMetadata)
 
   object ServiceWithConsole extends ZTestService[Context] {
-    def unary(request: Request, context: Context): ZIO[Any, StatusException, Response] =
+    def unary(request: Request, context: Context): ZIO[Any, StatusRuntimeException, Response] =
       for {
         _ <- context.response.put(RequestIdKey, "1")
-        _ <- ZIO.fail(Status.FAILED_PRECONDITION.asException()).when(context.user.name == "Eve")
+        _ <- ZIO.fail(Status.FAILED_PRECONDITION.asRuntimeException()).when(context.user.name == "Eve")
       } yield Response(context.user.name)
 
     def serverStreaming(
         request: Request,
         context: Context
-    ): ZStream[Any, StatusException, Response] =
+    ): ZStream[Any, StatusRuntimeException, Response] =
       ZStream
           .fromZIO(
             for {
               _ <- context.response.put(RequestIdKey, "1")
-              _ <- ZIO.fail(Status.FAILED_PRECONDITION.asException()).when(context.user.name == "Eve")
+              _ <- ZIO.fail(Status.FAILED_PRECONDITION.asRuntimeException()).when(context.user.name == "Eve")
             } yield ()
           )
           .drain ++
@@ -41,22 +41,22 @@ object EnvSpec extends ZIOSpecDefault with MetadataTests {
           )
 
     def clientStreaming(
-        request: ZStream[Any, StatusException, Request],
+        request: ZStream[Any, StatusRuntimeException, Request],
         context: Context
-    ): ZIO[Any, StatusException, Response] =
+    ): ZIO[Any, StatusRuntimeException, Response] =
       for {
         _ <- context.response.put(RequestIdKey, "1")
-        _ <- ZIO.fail(Status.FAILED_PRECONDITION.asException()).when(context.user.name == "Eve")
+        _ <- ZIO.fail(Status.FAILED_PRECONDITION.asRuntimeException()).when(context.user.name == "Eve")
       } yield Response(context.user.name)
 
     def bidiStreaming(
-        request: ZStream[Any, StatusException, Request],
+        request: ZStream[Any, StatusRuntimeException, Request],
         context: Context
-    ): ZStream[Any, StatusException, Response] =
+    ): ZStream[Any, StatusRuntimeException, Response] =
         ZStream.fromZIO(
           for {
             _ <- context.response.put(RequestIdKey, "1")
-            _ <- ZIO.fail(Status.FAILED_PRECONDITION.asException()).when(context.user.name == "Eve")
+            _ <- ZIO.fail(Status.FAILED_PRECONDITION.asRuntimeException()).when(context.user.name == "Eve")
           } yield ()
         ).drain ++ ZStream(Response(context.user.name))
   }
@@ -64,14 +64,14 @@ object EnvSpec extends ZIOSpecDefault with MetadataTests {
   val UserKey =
     Metadata.Key.of("user-key", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
 
-  def parseUser(rc: RequestContext): IO[StatusException, Context] =
+  def parseUser(rc: RequestContext): IO[StatusRuntimeException, Context] =
     rc.metadata.get(UserKey).flatMap {
       case Some("alice") =>
         ZIO.fail(
-          Status.PERMISSION_DENIED.withDescription("You are not allowed!").asException()
+          Status.PERMISSION_DENIED.withDescription("You are not allowed!").asRuntimeException()
         )
       case Some(name)    => ZIO.succeed(Context(User(name), rc.responseMetadata))
-      case None          => ZIO.fail(Status.UNAUTHENTICATED.asException())
+      case None          => ZIO.fail(Status.UNAUTHENTICATED.asRuntimeException())
     }
 
   val serviceLayer = ZLayer.succeed(ServiceWithConsole.transformContextZIO(parseUser(_)))

--- a/e2e/src/test/scala/scalapb/zio_grpc/ListenerDriverSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/ListenerDriverSpec.scala
@@ -17,11 +17,11 @@ object ListenerDriverSpec extends ZIOSpecDefault {
           for {
             delay <- nextIntBetween(100, 200)
             _     <- ClockLive.sleep(delay.milliseconds)
-            _     <- ZIO.fail(Status.INVALID_ARGUMENT.withDescription(s"i=$i").asException())
+            _     <- ZIO.fail(Status.INVALID_ARGUMENT.withDescription(s"i=$i").asRuntimeException())
           } yield ()
         )
         .withParallelism(128)
-      assertZIO(effectWithInterruptAndFailure.exit.map(ListenerDriver.exitToStatus(_).asException()))(
+      assertZIO(effectWithInterruptAndFailure.exit.map(ListenerDriver.exitToStatus(_).asRuntimeException()))(
         hasStatusCode(Status.INVALID_ARGUMENT)
       )
     }

--- a/e2e/src/test/scala/scalapb/zio_grpc/ListenerDriverSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/ListenerDriverSpec.scala
@@ -17,11 +17,11 @@ object ListenerDriverSpec extends ZIOSpecDefault {
           for {
             delay <- nextIntBetween(100, 200)
             _     <- ClockLive.sleep(delay.milliseconds)
-            _     <- ZIO.fail(Status.INVALID_ARGUMENT.withDescription(s"i=$i"))
+            _     <- ZIO.fail(Status.INVALID_ARGUMENT.withDescription(s"i=$i").asException())
           } yield ()
         )
         .withParallelism(128)
-      assertZIO(effectWithInterruptAndFailure.exit map ListenerDriver.exitToStatus)(
+      assertZIO(effectWithInterruptAndFailure.exit.map(ListenerDriver.exitToStatus(_).asException()))(
         hasStatusCode(Status.INVALID_ARGUMENT)
       )
     }

--- a/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
@@ -22,11 +22,11 @@ trait MetadataTests {
 
   val authClient   = clientLayer(Some("bob"))
   val unauthClient = clientLayer(Some("alice"))
-  val errorClient = clientLayer(Some("Eve"))
+  val errorClient  = clientLayer(Some("Eve"))
   val unsetClient  = clientLayer(None)
 
-  val permissionDenied = fails(hasStatusCode(Status.PERMISSION_DENIED))
-  val unauthenticated  = fails(hasStatusCode(Status.UNAUTHENTICATED))
+  val permissionDenied  = fails(hasStatusCode(Status.PERMISSION_DENIED))
+  val unauthenticated   = fails(hasStatusCode(Status.UNAUTHENTICATED))
   val errorWithTrailers = fails(hasStatusCode(Status.FAILED_PRECONDITION) && hasTrailerValue(RequestIdKey, "1"))
 
   val unaryEffect           = TestServiceClient.unary(Request())

--- a/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/MetadataTests.scala
@@ -22,14 +22,15 @@ trait MetadataTests {
 
   val authClient   = clientLayer(Some("bob"))
   val unauthClient = clientLayer(Some("alice"))
+  val errorClient = clientLayer(Some("Eve"))
   val unsetClient  = clientLayer(None)
 
   val permissionDenied = fails(hasStatusCode(Status.PERMISSION_DENIED))
   val unauthenticated  = fails(hasStatusCode(Status.UNAUTHENTICATED))
+  val errorWithTrailers = fails(hasStatusCode(Status.FAILED_PRECONDITION) && hasTrailerValue(RequestIdKey, "1"))
 
   val unaryEffect           = TestServiceClient.unary(Request())
-  val serverStreamingEffect =
-    TestServiceClient.serverStreaming(Request()).runCollect
+  val serverStreamingEffect = TestServiceClient.serverStreaming(Request()).runCollect
   val clientStreamingEffect = TestServiceClient.clientStreaming(ZStream.empty)
   val bidiEffect            = TestServiceClient.bidiStreaming(ZStream.empty).runCollect
 
@@ -150,10 +151,27 @@ trait MetadataTests {
       }
     ).provideLayer(clientMetadataLayer)
 
+  def errorWithTrailersSuite =
+    suite("errro response with trailers")(
+      test("unary") {
+        assertZIO(unaryEffect.exit)(errorWithTrailers)
+      },
+      test("server streaming") {
+        assertZIO(serverStreamingEffect.exit)(errorWithTrailers)
+      },
+      test("client streaming") {
+        assertZIO(clientStreamingEffect.exit)(errorWithTrailers)
+      },
+      test("bidi streaming") {
+        assertZIO(bidiEffect.exit)(errorWithTrailers)
+      }
+    ).provideLayer(errorClient)
+
   val specs = suite("Metadata")(
     permissionDeniedSuite,
     unauthenticatedSuite,
     authenticatedSuite,
+    errorWithTrailersSuite,
     metadataSuite
   ) @@ TestAspect.timeout(10.seconds)
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestServiceImpl.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestServiceImpl.scala
@@ -101,7 +101,9 @@ package object server {
               case Scenario.ERROR_NOW =>
                 ZStream.fail(Status.INTERNAL.withDescription("Intentional error").asRuntimeException())
               case _                  =>
-                ZStream.fail(Status.INVALID_ARGUMENT.withDescription(s"Got request: ${r.toProtoString}").asRuntimeException())
+                ZStream.fail(
+                  Status.INVALID_ARGUMENT.withDescription(s"Got request: ${r.toProtoString}").asRuntimeException()
+                )
             }
           } ++ ZStream(Response("DONE")))
             .ensuring(exit.succeed(Exit.succeed(Response()))))

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestServiceImpl.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestServiceImpl.scala
@@ -100,7 +100,8 @@ package object server {
               case Scenario.DIE       => ZStream.die(new RuntimeException("FOO"))
               case Scenario.ERROR_NOW =>
                 ZStream.fail(Status.INTERNAL.withDescription("Intentional error").asException())
-              case _                  => ZStream.fail(Status.INVALID_ARGUMENT.withDescription(s"Got request: ${r.toProtoString}").asException())
+              case _                  =>
+                ZStream.fail(Status.INVALID_ARGUMENT.withDescription(s"Got request: ${r.toProtoString}").asException())
             }
           } ++ ZStream(Response("DONE")))
             .ensuring(exit.succeed(Exit.succeed(Response()))))

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestServiceImpl.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestServiceImpl.scala
@@ -3,7 +3,7 @@ package scalapb.zio_grpc
 import scalapb.zio_grpc.testservice.Request
 import zio.{Clock, Console, Exit, Promise, ZIO, ZLayer}
 import scalapb.zio_grpc.testservice.Response
-import io.grpc.{Status, StatusException}
+import io.grpc.{Status, StatusRuntimeException}
 import scalapb.zio_grpc.testservice.Request.Scenario
 import zio.stream.{Stream, ZStream}
 import zio.ZEnvironment
@@ -19,32 +19,32 @@ package object server {
     class Service(
         requestReceived: zio.Promise[Nothing, Unit],
         delayReceived: zio.Promise[Nothing, Unit],
-        exit: zio.Promise[Nothing, Exit[StatusException, Response]]
+        exit: zio.Promise[Nothing, Exit[StatusRuntimeException, Response]]
     )(clock: Clock, console: Console)
         extends testservice.ZioTestservice.TestService {
-      def unary(request: Request): ZIO[Any, StatusException, Response] =
+      def unary(request: Request): ZIO[Any, StatusRuntimeException, Response] =
         (requestReceived.succeed(()) *> (request.scenario match {
           case Scenario.OK        =>
             ZIO.succeed(
               Response(out = "Res" + request.in.toString)
             )
           case Scenario.ERROR_NOW =>
-            ZIO.fail(Status.INTERNAL.withDescription("FOO!").asException())
+            ZIO.fail(Status.INTERNAL.withDescription("FOO!").asRuntimeException())
           case Scenario.DELAY     => ZIO.never
           case Scenario.DIE       => ZIO.die(new RuntimeException("FOO"))
-          case _                  => ZIO.fail(Status.UNKNOWN.asException())
+          case _                  => ZIO.fail(Status.UNKNOWN.asRuntimeException())
         })).onExit(exit.succeed(_))
 
       def serverStreaming(
           request: Request
-      ): ZStream[Any, StatusException, Response] =
+      ): ZStream[Any, StatusRuntimeException, Response] =
         ZStream
           .acquireReleaseExitWith(requestReceived.succeed(())) { (_, ex) =>
             ex.foldExit(
               failed =>
                 if (failed.isInterrupted || failed.isInterruptedOnly)
-                  exit.succeed(Exit.fail(Status.CANCELLED.asException()))
-                else exit.succeed(Exit.fail(Status.UNKNOWN.asException())),
+                  exit.succeed(Exit.fail(Status.CANCELLED.asRuntimeException()))
+                else exit.succeed(Exit.fail(Status.UNKNOWN.asRuntimeException())),
               _ => exit.succeed(Exit.succeed(Response()))
             )
           }
@@ -53,11 +53,11 @@ package object server {
               case Scenario.OK          =>
                 ZStream(Response(out = "X1"), Response(out = "X2"))
               case Scenario.ERROR_NOW   =>
-                ZStream.fail(Status.INTERNAL.withDescription("FOO!").asException())
+                ZStream.fail(Status.INTERNAL.withDescription("FOO!").asRuntimeException())
               case Scenario.ERROR_AFTER =>
                 ZStream(Response(out = "X1"), Response(out = "X2")) ++ ZStream
                   .fail(
-                    Status.INTERNAL.withDescription("FOO!").asException()
+                    Status.INTERNAL.withDescription("FOO!").asRuntimeException()
                   )
               case Scenario.DELAY       =>
                 ZStream(
@@ -65,13 +65,13 @@ package object server {
                   Response(out = "X2")
                 ) ++ ZStream.never
               case Scenario.DIE         => ZStream.die(new RuntimeException("FOO"))
-              case _                    => ZStream.fail(Status.UNKNOWN.asException())
+              case _                    => ZStream.fail(Status.UNKNOWN.asRuntimeException())
             }
           }
 
       def clientStreaming(
-          request: Stream[StatusException, Request]
-      ): ZIO[Any, StatusException, Response] =
+          request: Stream[StatusRuntimeException, Request]
+      ): ZIO[Any, StatusRuntimeException, Response] =
         requestReceived.succeed(()) *>
           request
             .runFoldZIO(0)((state, req) =>
@@ -80,16 +80,16 @@ package object server {
                 case Scenario.DELAY     => delayReceived.succeed(()) *> ZIO.never
                 case Scenario.DIE       => ZIO.die(new RuntimeException("foo"))
                 case Scenario.ERROR_NOW =>
-                  ZIO.fail((Status.INTERNAL.withDescription("InternalError").asException()))
-                case _: Scenario        => ZIO.fail(Status.UNKNOWN.asException())
+                  ZIO.fail((Status.INTERNAL.withDescription("InternalError").asRuntimeException()))
+                case _: Scenario        => ZIO.fail(Status.UNKNOWN.asRuntimeException())
               }
             )
             .map(r => Response(r.toString))
             .onExit(exit.succeed(_))
 
       def bidiStreaming(
-          request: Stream[StatusException, Request]
-      ): Stream[StatusException, Response] =
+          request: Stream[StatusRuntimeException, Request]
+      ): Stream[StatusRuntimeException, Response] =
         (ZStream.fromZIO(requestReceived.succeed(())).drain ++
           (request.flatMap { r =>
             r.scenario match {
@@ -99,9 +99,9 @@ package object server {
               case Scenario.DELAY     => ZStream.never
               case Scenario.DIE       => ZStream.die(new RuntimeException("FOO"))
               case Scenario.ERROR_NOW =>
-                ZStream.fail(Status.INTERNAL.withDescription("Intentional error").asException())
+                ZStream.fail(Status.INTERNAL.withDescription("Intentional error").asRuntimeException())
               case _                  =>
-                ZStream.fail(Status.INVALID_ARGUMENT.withDescription(s"Got request: ${r.toProtoString}").asException())
+                ZStream.fail(Status.INVALID_ARGUMENT.withDescription(s"Got request: ${r.toProtoString}").asRuntimeException())
             }
           } ++ ZStream(Response("DONE")))
             .ensuring(exit.succeed(Exit.succeed(Response()))))
@@ -121,7 +121,7 @@ package object server {
       for {
         p1 <- Promise.make[Nothing, Unit]
         p2 <- Promise.make[Nothing, Unit]
-        p3 <- Promise.make[Nothing, Exit[StatusException, Response]]
+        p3 <- Promise.make[Nothing, Exit[StatusRuntimeException, Response]]
       } yield new Service(p1, p2, p3)(clock, console)
 
     def makeFromEnv: ZIO[Any, Nothing, Service] =
@@ -142,7 +142,7 @@ package object server {
     def awaitDelayReceived: ZIO[TestServiceImpl, Nothing, Unit] =
       ZIO.environmentWithZIO(_.get.awaitDelayReceived)
 
-    def awaitExit: ZIO[TestServiceImpl, Nothing, Exit[StatusException, Response]] =
+    def awaitExit: ZIO[TestServiceImpl, Nothing, Exit[StatusRuntimeException, Response]] =
       ZIO.environmentWithZIO(_.get.awaitExit)
   }
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestServiceSpec.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc
 
-import io.grpc.{ManagedChannelBuilder, ServerBuilder, Status}
+import io.grpc.{ManagedChannelBuilder, ServerBuilder, Status, StatusException}
 import scalapb.zio_grpc.TestUtils._
 import scalapb.zio_grpc.server.TestServiceImpl
 import scalapb.zio_grpc.testservice.Request.Scenario
@@ -228,7 +228,7 @@ object TestServiceSpec extends ZIOSpecDefault {
   case class BidiFixture[Req, Res](
       in: Queue[Res],
       out: Queue[Option[Req]],
-      fiber: Fiber[Status, Unit]
+      fiber: Fiber[StatusException, Unit]
   ) {
     def send(r: Req) = out.offer(Some(r))
 
@@ -239,7 +239,7 @@ object TestServiceSpec extends ZIOSpecDefault {
 
   object BidiFixture {
     def apply[R, Req, Res](
-        call: Stream[Status, Req] => ZStream[R, Status, Res]
+        call: Stream[StatusException, Req] => ZStream[R, StatusException, Res]
     ): zio.URIO[R, BidiFixture[Req, Res]] =
       for {
         in    <- Queue.unbounded[Res]
@@ -296,7 +296,7 @@ object TestServiceSpec extends ZIOSpecDefault {
                                    ZStream(
                                      Request(Scenario.OK, in = 17)
                                    ) ++ ZStream.fromZIO(testServiceImpl.get.awaitReceived).drain
-                                     ++ ZStream.fail(Status.CANCELLED)
+                                     ++ ZStream.fail(Status.CANCELLED.asException())
                                  )
                                ).fork
             _               <- testServiceImpl.get.awaitExit

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestServiceSpec.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestServiceSpec.scala
@@ -1,6 +1,6 @@
 package scalapb.zio_grpc
 
-import io.grpc.{ManagedChannelBuilder, ServerBuilder, Status, StatusException}
+import io.grpc.{ManagedChannelBuilder, ServerBuilder, Status, StatusRuntimeException}
 import scalapb.zio_grpc.TestUtils._
 import scalapb.zio_grpc.server.TestServiceImpl
 import scalapb.zio_grpc.testservice.Request.Scenario
@@ -228,7 +228,7 @@ object TestServiceSpec extends ZIOSpecDefault {
   case class BidiFixture[Req, Res](
       in: Queue[Res],
       out: Queue[Option[Req]],
-      fiber: Fiber[StatusException, Unit]
+      fiber: Fiber[StatusRuntimeException, Unit]
   ) {
     def send(r: Req) = out.offer(Some(r))
 
@@ -239,7 +239,7 @@ object TestServiceSpec extends ZIOSpecDefault {
 
   object BidiFixture {
     def apply[R, Req, Res](
-        call: Stream[StatusException, Req] => ZStream[R, StatusException, Res]
+        call: Stream[StatusRuntimeException, Req] => ZStream[R, StatusRuntimeException, Res]
     ): zio.URIO[R, BidiFixture[Req, Res]] =
       for {
         in    <- Queue.unbounded[Res]
@@ -296,7 +296,7 @@ object TestServiceSpec extends ZIOSpecDefault {
                                    ZStream(
                                      Request(Scenario.OK, in = 17)
                                    ) ++ ZStream.fromZIO(testServiceImpl.get.awaitReceived).drain
-                                     ++ ZStream.fail(Status.CANCELLED.asException())
+                                     ++ ZStream.fail(Status.CANCELLED.asRuntimeException())
                                  )
                                ).fork
             _               <- testServiceImpl.get.awaitExit

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
@@ -1,13 +1,16 @@
 package scalapb.zio_grpc
 
 import zio.test.Assertion._
-import io.grpc.Status
+import io.grpc.{Metadata, Status, StatusException}
 import io.grpc.Status.Code
 
 object TestUtils {
   def hasStatusCode(c: Status) =
-    hasField[Status, Code]("code", _.getCode, equalTo(c.getCode))
+    hasField[StatusException, Code]("code", _.getStatus().getCode, equalTo(c.getCode))
 
   def hasDescription(d: String) =
-    hasField[Status, String]("description", d => Option(d.getDescription()).getOrElse("GotNull"), equalTo(d))
+    hasField[StatusException, String]("description", e => Option(e.getStatus().getDescription()).getOrElse("GotNull"), equalTo(d))
+
+  def hasTrailerValue[T](key: Metadata.Key[T], value: T) =
+    hasField[StatusException, T]("trailers", e => Status.trailersFromThrowable(e).get(key), equalTo(value))
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
@@ -1,20 +1,20 @@
 package scalapb.zio_grpc
 
 import zio.test.Assertion._
-import io.grpc.{Metadata, Status, StatusException}
+import io.grpc.{Metadata, Status, StatusRuntimeException}
 import io.grpc.Status.Code
 
 object TestUtils {
   def hasStatusCode(c: Status) =
-    hasField[StatusException, Code]("code", _.getStatus().getCode, equalTo(c.getCode))
+    hasField[StatusRuntimeException, Code]("code", _.getStatus().getCode, equalTo(c.getCode))
 
   def hasDescription(d: String) =
-    hasField[StatusException, String](
+    hasField[StatusRuntimeException, String](
       "description",
       e => Option(e.getStatus().getDescription()).getOrElse("GotNull"),
       equalTo(d)
     )
 
   def hasTrailerValue[T](key: Metadata.Key[T], value: T) =
-    hasField[StatusException, T]("trailers", e => Status.trailersFromThrowable(e).get(key), equalTo(value))
+    hasField[StatusRuntimeException, T]("trailers", e => Status.trailersFromThrowable(e).get(key), equalTo(value))
 }

--- a/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
+++ b/e2e/src/test/scala/scalapb/zio_grpc/TestUtils.scala
@@ -9,7 +9,11 @@ object TestUtils {
     hasField[StatusException, Code]("code", _.getStatus().getCode, equalTo(c.getCode))
 
   def hasDescription(d: String) =
-    hasField[StatusException, String]("description", e => Option(e.getStatus().getDescription()).getOrElse("GotNull"), equalTo(d))
+    hasField[StatusException, String](
+      "description",
+      e => Option(e.getStatus().getDescription()).getOrElse("GotNull"),
+      equalTo(d)
+    )
 
   def hasTrailerValue[T](key: Metadata.Key[T], value: T) =
     hasField[StatusException, T]("trailers", e => Status.trailersFromThrowable(e).get(key), equalTo(value))


### PR DESCRIPTION
From https://github.com/scalapb/zio-grpc/pull/459, I also worked on handling trailers on error for ZIO 2.
For convenient and clear implementation, I changed the error type `Status` to `StatusException`.
It can cause to break backward compatibility, so please check it carefully.

This PR is working on JVM(2_12, 2_13, 3), but not working on JS since the library `scalapb-grpcweb` does not have `io.grpc.StatusException`. If maintainers agree with my PR, I also will work on adding `io.grpc.StatusException` on `scalapb-grpc-web`.