### PR TITLE
fix: significant performance drop with `stream.toQueue`

### DIFF
--- a/benchmarks/src/main/protobuf/testservice.proto
+++ b/benchmarks/src/main/protobuf/testservice.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "scalapb.zio_grpc.helloworld";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  // Sends a litany of greetings
+  rpc SayHelloStreaming (HelloRequest) returns (stream HelloReply) {}
+}
+
+// The actual message exchanged by the client and the server.
+message Hello {
+  string name = 1;
+  double d = 2;
+  float f = 3;
+  bool b = 4;
+  int32 n = 5;
+  int64 l = 6;
+  oneof choice {
+    string c1 = 7;
+    bool c2 = 8;
+  }
+  message Pet {
+    enum Color {
+      BLACK = 0;
+      WHITE = 1;
+      BLUE = 2;
+      RED = 3;
+      YELLOW = 4;
+      GREEN = 5;
+    }
+    string name = 1;
+    Color color = 2;
+  }
+  repeated Pet pets = 9;
+}
+
+// The request message from the client.
+message HelloRequest {
+  Hello request = 1;
+}
+
+// The response message from the server.
+message HelloReply {
+  Hello response = 1;
+}

--- a/benchmarks/src/main/scala/scalapb/zio_grpc/GreeterImpl.scala
+++ b/benchmarks/src/main/scala/scalapb/zio_grpc/GreeterImpl.scala
@@ -1,0 +1,17 @@
+package scalapb.zio_grpc
+
+import scalapb.zio_grpc.helloworld.testservice.ZioTestservice.ZGreeter
+import scalapb.zio_grpc.helloworld.testservice.{HelloReply, HelloRequest}
+import io.grpc.Status
+import zio.ZIO
+import zio.stream.ZStream
+
+class GreeterImpl(size: Long) extends ZGreeter[Any] {
+
+  def sayHello(request: HelloRequest): ZIO[Any, Status, HelloReply] =
+    ZIO.succeed(HelloReply(request.request))
+
+  def sayHelloStreaming(request: HelloRequest): ZStream[Any, Status, HelloReply] =
+    ZStream.repeat(HelloReply(request.request)).take(size)
+
+}

--- a/benchmarks/src/main/scala/scalapb/zio_grpc/ServerStreamingBenchmarkApp.scala
+++ b/benchmarks/src/main/scala/scalapb/zio_grpc/ServerStreamingBenchmarkApp.scala
@@ -1,0 +1,59 @@
+package scalapb.zio_grpc
+
+import io.grpc.ManagedChannelBuilder
+import io.grpc.ServerBuilder
+import scalapb.zio_grpc.helloworld.testservice._
+import zio._
+import java.time
+
+object ServerStreamingBenchmarkApp extends ZIOAppDefault {
+
+  val size = 100000L
+
+  val server =
+    ServerLayer.fromEnvironment[ZioTestservice.Greeter](ServerBuilder.forPort(50051))
+
+  val client =
+    ZLayer.scoped[Server] {
+      for {
+        ss     <- ZIO.service[Server]
+        port   <- ss.port.orDie
+        ch      = ManagedChannelBuilder.forAddress("localhost", 50051).usePlaintext()
+        client <- ZioTestservice.GreeterClient.scoped(ZManagedChannel(ch)).orDie
+      } yield client
+    }
+
+  val service =
+    ZLayer.succeed[ZioTestservice.Greeter] {
+      new GreeterImpl(size)
+    }
+
+  def run = ZIO
+    .foreach(Array(8192, 65536)) { queueSize =>
+      val props = java.lang.System.getProperties();
+      props.setProperty("zio-grpc.backpressure-queue-size", queueSize.toString());
+
+      for {
+        _      <- Console.printLine(s"Starting with queue size $queueSize")
+        cpt    <- Ref.make(0)
+        start  <- Clock.instant.flatMap(Ref.make(_))
+        result <- ZioTestservice.GreeterClient
+                    .sayHelloStreaming(HelloRequest(request = Some(Hello(name = "Testing streaming"))))
+                    .tap(_ => cpt.update(_ + 1))
+                    .tap { _ =>
+                      for {
+                        now     <- Clock.instant
+                        started <- start.get
+                        _       <- ZIO.when(time.Duration.between(started, now).toSeconds() >= 10)(
+                                     start.set(now) *> cpt.get.flatMap(cpt => Console.printLine(s"Received $cpt messages"))
+                                   )
+                      } yield ()
+                    }
+                    .runDrain
+                    .timed
+        _      <- Console.printLine(s"queue size: $queueSize (${result._1.toMillis()}ms)")
+      } yield ()
+    }
+    .provide(service >+> server >+> client)
+
+}


### PR DESCRIPTION
In the process of upgrading to zio 2, we have noticed a dramatic drop (50x) of performance with server streaming.

After running some tests I've been able to isolate it to the implementation of `toQueue` in the new streaming API. Here I replace it with `toQueueOfElements` which is IMO easier to deal with and more concise.

Informal tests to stream 100000 small objects:

- zio 1: ~5-10s
- zio 2 with `toQueue`: +90s
- zio 2 with `toQueueOfElements`: ~2-5s