### PR TITLE
Optimise backpressure loop

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCall.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCall.scala
@@ -7,7 +7,7 @@ import zio.stm.TSemaphore
 import zio.UIO
 
 /** Wrapper around [[io.grpc.ServerCall]] that lifts its effects into ZIO values */
-final class ZServerCall[Res](private val call: ServerCall[_, Res], private val canSend: TSemaphore) {
+final class ZServerCall[Res](private[zio_grpc] val call: ServerCall[_, Res], private val canSend: TSemaphore) {
   def isReady: UIO[Boolean] = ZIO.succeed(call.isReady())
 
   def request(n: Int): GIO[Unit] = GIO.fromTask(ZIO.attempt(call.request(n)))

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -11,6 +11,8 @@ import scalapb.zio_grpc.RequestContext
 import io.grpc.Metadata
 import scalapb.zio_grpc.SafeMetadata
 import zio.stm.TSemaphore
+import zio.Exit.Failure
+import zio.Exit.Success
 
 class ZServerCallHandler[Req, Res](
     runtime: Runtime[Any],
@@ -108,30 +110,64 @@ object ZServerCallHandler {
       call: ZServerCall[Res],
       stream: ZStream[Any, Status, Res]
   ): ZIO[Any, Status, Unit] = {
-    def innerLoop(queue: Dequeue[Exit[Option[Status], Res]]): ZIO[Any, Status, Boolean] =
-      queue.take
-        .flatMap {
-          case Exit.Success(res)   => call.sendMessage(res).as(true)
-          case Exit.Failure(cause) =>
-            cause.failureOrCause match {
-              case Left(Some(status)) => ZIO.fail(status)
-              case Left(None)         => ZIO.succeed(false)
-              case Right(cause)       => ZIO.failCause(cause)
-            }
-        }
-        .repeatWhileZIO(res => call.isReady.map(_ && res))
+    def takeFromQueue(queue: Dequeue[Exit[Option[Status], Res]]): ZIO[Any, Status, Unit] =
+      queue.takeAll.flatMap(takeFromCache(_, queue))
 
-    def outerLoop(queue: Dequeue[Exit[Option[Status], Res]]): ZIO[Any, Status, Boolean] =
-      (call.awaitReady *> innerLoop(queue))
-        .repeatWhile(identity)
+    def takeFromCache(
+        xs: Chunk[Exit[Option[Status], Res]],
+        queue: Dequeue[Exit[Option[Status], Res]]
+    ): ZIO[Any, Status, Unit] =
+      ZIO.succeed {
+        var i                          = 0
+        var done                       = false
+        var loop                       = true
+        var error: IO[Status, Nothing] = null
+        while (i < xs.length && loop) {
+          xs(i) match {
+            case Failure(cause) =>
+              loop = false
+              done = true
+              cause.failureOrCause match {
+                case Left(Some(status)) =>
+                  error = ZIO.fail(status)
+                case Left(None)         =>
+                case Right(cause)       =>
+                  error = ZIO.failCause(cause)
+              }
+            case Success(value) =>
+              call.call.sendMessage(value)
+              loop = call.call.isReady
+          }
+          i += 1
+        }
+
+        if (done)
+          if (error ne null)
+            error
+          else
+            ZIO.unit
+        else if (i < xs.length)
+          outerLoop(Some(xs.drop(i)), queue)
+        else
+          takeFromQueue(queue)
+      }.flatten
+
+    def outerLoop(
+        cache: Option[Chunk[Exit[Option[Status], Res]]],
+        queue: Dequeue[Exit[Option[Status], Res]]
+    ): ZIO[Any, Status, Unit] =
+      (call.awaitReady *> cache.fold(takeFromQueue(queue))(takeFromCache(_, queue)))
 
     for {
       queueSize <- backpressureQueueSize
-      _         <- ZIO.scoped[Any](
-                     stream
-                       .toQueueOfElements(queueSize)
-                       .flatMap(outerLoop)
-                   )
+      fiber     <- ZIO
+                     .scoped[Any](
+                       stream
+                         .toQueueOfElements(queueSize)
+                         .flatMap(outerLoop(None, _))
+                     )
+                     .fork
+      _         <- fiber.join
     } yield ()
   }
 }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -118,7 +118,7 @@ object ZServerCallHandler {
         xs: Chunk[Exit[Option[Status], Res]],
         queue: Dequeue[Exit[Option[Status], Res]]
     ): ZIO[Any, Status, Unit] =
-      ZIO.succeed {
+      ZIO.suspendSucceed {
         @tailrec def innerLoop(loop: Boolean, i: Int): IO[Status, Unit] =
           if (loop) {
             xs(i) match {
@@ -148,7 +148,7 @@ object ZServerCallHandler {
             outerLoop(Some(xs.drop(i)), queue)
 
         innerLoop(0 < xs.length, 0)
-      }.flatten
+      }
 
     def outerLoop(
         cache: Option[Chunk[Exit[Option[Status], Res]]],

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -160,14 +160,12 @@ object ZServerCallHandler {
 
     for {
       queueSize <- backpressureQueueSize
-      fiber     <- ZIO
+      _         <- ZIO
                      .scoped[Any](
                        stream
                          .toQueueOfElements(queueSize)
-                         .flatMap(outerLoop(None, _))
+                         .flatMap(outerLoop(None, _).fork.flatMap(_.join))
                      )
-                     .fork
-      _         <- fiber.join
     } yield ()
   }
 }

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -120,7 +120,7 @@ object ZServerCallHandler {
     ): ZIO[Any, Status, Unit] =
       ZIO.suspendSucceed {
         @tailrec def innerLoop(loop: Boolean, i: Int): IO[Status, Unit] =
-          if (loop) {
+          if (i < xs.length && loop) {
             xs(i) match {
               case Failure(cause) =>
                 cause.failureOrCause match {
@@ -133,11 +133,9 @@ object ZServerCallHandler {
                 }
               case Success(value) =>
                 call.call.sendMessage(value)
-                // at this point we have consumed i + 1 elements from the chunk
-                val newI = i + 1
                 // the loop iteration may only continue if the call can
                 // still accept elements and we have more elements to send
-                innerLoop(call.call.isReady && newI < xs.length, newI)
+                innerLoop(call.call.isReady, i + 1)
             }
           } else if (call.call.isReady)
             // ^ if we reached the end of the chunk but the call can still

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -137,7 +137,7 @@ object ZServerCallHandler {
                 // still accept elements and we have more elements to send
                 innerLoop(call.call.isReady, i + 1)
             }
-          } else if (call.call.isReady)
+          } else if (loop)
             // ^ if we reached the end of the chunk but the call can still
             // proceed, we pull from the queue and continue
             takeFromQueue(queue)

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -122,7 +122,7 @@ object ZServerCallHandler {
         var done                       = false
         var loop                       = true
         var error: IO[Status, Nothing] = null
-        while (i < xs.length && loop) {
+        while (i < xs.length && loop)
           xs(i) match {
             case Failure(cause) =>
               loop = false
@@ -137,9 +137,8 @@ object ZServerCallHandler {
             case Success(value) =>
               call.call.sendMessage(value)
               loop = call.call.isReady
+              i += 1
           }
-          i += 1
-        }
 
         if (done)
           if (error ne null)

--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -147,7 +147,10 @@ object ZServerCallHandler {
             // ^ otherwise, we wait for the call to be ready and then start again
             outerLoop(Some(xs.drop(i)), queue)
 
-        innerLoop(0 < xs.length, 0)
+        if (xs.isEmpty)
+          takeFromQueue(queue)
+        else
+          innerLoop(true, 0)
       }
 
     def outerLoop(


### PR DESCRIPTION
After more testing it seems like we can do much better:

- take _all_ elements in the queue instead of one-by-one: I did the same thing [in the ZIO codebase](https://github.com/zio/zio/pull/7763) to avoid the overhead of the IO run loop.
- use imperative loop: the `IllegalStateException` are prevented already, so we can use a loop to unroll the chunk of elements from the queue and using the grpc `ServerCall[_, _]` instance directly
~~- fork the whole loop, I don't know how I missed that one~~