### PR TITLE
bumped grpc version

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,4 +1,4 @@
 object Version {
   val zio  = "2.0.19"
-  val grpc = "1.47.0"
+  val grpc = "1.54.2"
 }


### PR DESCRIPTION
The grpc version being used does not seem to be compatible with higher versions, namely `1.54.2`