### PR TITLE
Only buffer stream if queue size is positive

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ZServerCallHandler.scala
@@ -122,7 +122,7 @@ object ZServerCallHandler {
 
     for {
       queueSize <- backpressureQueueSize
-      _         <- stream.buffer(queueSize).run(backpressureSink)
+      _         <- (if (queueSize > 0) stream.buffer(queueSize) else stream).run(backpressureSink)
     } yield ()
   }
 }


### PR DESCRIPTION
See discussion here: https://github.com/scalapb/zio-grpc/pull/514#issuecomment-1797901101

This change allows setting a queue size of 0 or -1 to prevent the buffering and preserve the chunk structure, which is desirable when working with many small messages.