### PR TITLE
provide request in context transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ examples/project/metals.sbt
 website/node_modules
 website/build
 website/i18n/en.json
+
+.DS_Store

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 ThisBuild / versionScheme := Some("early-semver")
 
+ThisBuild / version := "0.6.1"
+
 publish / skip := true
 
 sonatypeProfileName := "com.thesamet"

--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -233,9 +233,9 @@ class ZioFilePrinter(
       val delegate = s"self.${method.name}"
       val newImpl  = method.streamType match {
         case StreamType.Unary | StreamType.ClientStreaming         =>
-          s"f.effect($delegate(request, _))(context)"
+          s"f.effect($delegate)(request, context)"
         case StreamType.ServerStreaming | StreamType.Bidirectional =>
-          s"f.stream($delegate(request, _))(context)"
+          s"f.stream($delegate)(request, context)"
       }
       fp.add(
         methodSignature(
@@ -630,7 +630,7 @@ class ZioFilePrinter(
       ).indent
         .add(s"$makeMetadata.flatMap { metadata =>")
         .indented(
-          _.add(s"transforms.$transformMethod { context => ")
+          _.add(s"transforms.$transformMethod { (_: Any, context) => ")
             .indented(
               _.add(
                 s"$clientCall("
@@ -644,7 +644,7 @@ class ZioFilePrinter(
                 )
                 .add(")")
             )
-            .add(s"}($ClientCallContext(${method.grpcDescriptor.fullName}, $CallOptions.DEFAULT, metadata))")
+            .add(s"}(request, $ClientCallContext(${method.grpcDescriptor.fullName}, $CallOptions.DEFAULT, metadata))")
         )
         .add("}")
         .outdent

--- a/e2e/src/test/scalajvm/scalapb/zio_grpc/ClientTransformSpec.scala
+++ b/e2e/src/test/scalajvm/scalapb/zio_grpc/ClientTransformSpec.scala
@@ -19,7 +19,10 @@ object ClientTransformSpec extends ZIOSpecDefault {
     for {
       metadata <- SafeMetadata.make
       context  <-
-        transform.effect(ZIO.succeed(_))(ClientCallContext(TestServiceGrpc.METHOD_UNARY, CallOptions.DEFAULT, metadata))
+        transform.effect((_: Any, c) => ZIO.succeed(c))(
+          (),
+          ClientCallContext(TestServiceGrpc.METHOD_UNARY, CallOptions.DEFAULT, metadata)
+        )
     } yield context
 
   def spec = suite("ClientTransformSpec")(

--- a/examples/fullapp/build.sbt
+++ b/examples/fullapp/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / cancelable := true
 
 ThisBuild / connectInput := true
 
-val grpcVersion = "1.50.1"
+val grpcVersion = "1.59.0"
 
 lazy val protos = crossProject(JSPlatform, JVMPlatform)
   .in(file("protos"))

--- a/examples/fullapp/project/plugins.sbt
+++ b/examples/fullapp/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
-val zioGrpcVersion = "0.6.0-rc6"
+val zioGrpcVersion = "0.6.1"
 
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % zioGrpcVersion,

--- a/examples/fullapp/server/src/main/scala/ExampleServer.scala
+++ b/examples/fullapp/server/src/main/scala/ExampleServer.scala
@@ -75,6 +75,6 @@ object GreeterService extends ZGreeter[RequestContext] {
 
 object ExampleServer extends ServerMain {
   def services = ServiceList.add(
-    GreeterService.transformContextZIO(RequestContext.fromMetadata(_))
+    GreeterService.transformContextZIO(RequestContext.fromMetadata).transform(LoggingTransform)
   )
 }

--- a/examples/fullapp/server/src/main/scala/ExampleServerWithMetadata.scala
+++ b/examples/fullapp/server/src/main/scala/ExampleServerWithMetadata.scala
@@ -92,7 +92,7 @@ object GreeterServiceWithMetadata {
   val layer
       : ZLayer[UserRepo with GreetingsRepo, Nothing, ZGreeter[RequestContext]] =
     ZLayer.fromFunction((userRepo: UserRepo, greetingsRepo: GreetingsRepo) =>
-      GreeterImpl(greetingsRepo).transformContextZIO(findUser(userRepo, _))
+      GreeterImpl(greetingsRepo).transformContextZIO(findUser(userRepo, _)).transform(LoggingTransform)
     )
 }
 

--- a/examples/fullapp/server/src/main/scala/LoggingTransform.scala
+++ b/examples/fullapp/server/src/main/scala/LoggingTransform.scala
@@ -1,0 +1,30 @@
+package examples
+
+import io.grpc.StatusException
+import scalapb.zio_grpc.Transform
+import zio._
+import zio.stream._
+
+object LoggingTransform extends Transform {
+  override def effect[A, B](io: A => IO[StatusException, B]): A => IO[StatusException, B] = { a =>
+    for {
+      _ <- ZIO.log(s"Received request: $a")
+      b <- io(a)
+      _ <- ZIO.log(s"Responding with: $b")
+    } yield b
+  }
+
+  override def stream[A, B](io: A => Stream[StatusException, B]): A => Stream[StatusException, B] = { a =>
+    val logOutput = (b: B) => ZIO.log(s"Responding with: $b")
+
+    a match {
+      case s: Stream[StatusException, Any] @unchecked =>
+        val loggedInput = s.tap(r => ZIO.log(s"Received request: $r")).asInstanceOf[A]
+        io(loggedInput).tap(logOutput)
+
+      case _ =>
+        val logInput = ZIO.log(s"Received request: $a")
+        ZStream.fromZIO(logInput).drain ++ io(a).tap(logOutput)
+    }
+  }
+}


### PR DESCRIPTION
### Goal

Add request parameter to `GTransform`

### Rationale
To be able to decorate a service with an access log, as advertised in the docs.
See [LoggingTransform](https://github.com/rtkaczyk/zio-grpc/blob/a7056996e26ffc5d561b25c2f38a17e82dd1db47/examples/fullapp/server/src/main/scala/LoggingTransform.scala) for an example.
