### PR TITLE
Don't block threads when interrupting fibers

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/server/ListenerDriver.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/server/ListenerDriver.scala
@@ -40,7 +40,7 @@ object ListenerDriver {
         new Listener[Req] {
           override def onCancel(): Unit =
             Unsafe.unsafe { implicit u =>
-              runtime.unsafe.run(fiber.interrupt.unit).getOrThrowFiberFailure()
+              runtime.unsafe.run(fiber.interruptFork.unit).getOrThrowFiberFailure()
             }
 
           override def onHalfClose(): Unit =
@@ -122,7 +122,7 @@ object ListenerDriver {
         new Listener[Req] {
           override def onCancel(): Unit =
             Unsafe.unsafe { implicit u =>
-              runtime.unsafe.run(fiber.interrupt.unit).getOrThrowFiberFailure()
+              runtime.unsafe.run(fiber.interruptFork.unit).getOrThrowFiberFailure()
             }
 
           override def onHalfClose(): Unit =


### PR DESCRIPTION
Fiber's `interrupt` completes only once the fiber is stopped, and because in `ListenerDriver` it's called by `unsafe.run` it means that it will block the current thread until it's over. `Interrupt` will trigger the finalizer from `onExit`, which calls `call.close` which needs to run on the gRPC threadpool (the same where the current thread is being blocked).

If you receive a lot of cancel calls at the same time, all threads might end up being blocked. It's ok when your threadpool is unbounded (which is the default), but when using a bounded threadpool (fixed or ForkJoin) [as recommended in the docs](https://grpc.io/docs/guides/performance/#java), this is a deadlock.

See the attached screenshot: using `ForkJoinPool`, when we receive a lot of stream disconnections, all threads end up being blocked on the `unsafe.run` of `fiber.interrupt`.
<img width="1760" alt="Screenshot 2024-03-20 at 10 33 55 AM" src="https://github.com/scalapb/zio-grpc/assets/7413894/ab49164f-735d-426a-8968-09a01616336c">

This PR changes it to `fiber.interruptFork` to prevent being blocked while the fiber is interrupted.