### PR TITLE
Suspend the creation of Metadata in make with pairs

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/SafeMetadata.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/SafeMetadata.scala
@@ -37,13 +37,14 @@ final class SafeMetadata private (
 object SafeMetadata {
   def make: UIO[SafeMetadata] = fromMetadata(new Metadata)
 
-  def make(pairs: (String, String)*): UIO[SafeMetadata] = {
-    val md = new Metadata
-    pairs.foreach { case (key, value) =>
-      md.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value)
+  def make(pairs: (String, String)*): UIO[SafeMetadata] =
+    ZIO.suspendSucceed {
+      val md = new Metadata
+      pairs.foreach { case (key, value) =>
+        md.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value)
+      }
+      SafeMetadata.fromMetadata(md)
     }
-    SafeMetadata.fromMetadata(md)
-  }
 
   /** Creates a new SafeMetadata by taking ownership of the given metadata. The provided metadata should not be used
     * after calling this method.


### PR DESCRIPTION
The variant of `SafeMetadata.make` that takes pairs creates the `Metadata` object eagerly outside of the effect. That means that the same `Metadata` object will be used everytime we create `SafeMetadata`. That leads to catastrophic behavior as that object is not supposed to be shared and reused (`java.lang.NullPointerException: Cannot invoke "io.grpc.Metadata$LazyValue.toBytes()" because "value" is null` or `Uncaught exception in the SynchronizationContext. Panic!` in Netty).

This PR makes the creation of `Metadata` lazy.