### PR TITLE
Don't use private[this] in generated code

### DIFF
--- a/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
+++ b/code-gen/src/main/scala/scalapb/zio_grpc/ZioCodeGenerator.scala
@@ -431,7 +431,7 @@ class ZioFilePrinter(
         )
         .indent
         .add(
-          s"private[this] class ServiceStub(channel: $ZChannel, transforms: $ClientTransform)"
+          s"private class ServiceStub(channel: $ZChannel, transforms: $ClientTransform)"
         )
         .add(s"    extends ${clientWithResponseMetadataServiceName.name} {")
         .indented(
@@ -513,7 +513,7 @@ class ZioFilePrinter(
         .indent
         .add("")
         .add(
-          s"private[this] class ServiceStub(underlying: ${clientWithResponseMetadataServiceName.name})"
+          s"private class ServiceStub(underlying: ${clientWithResponseMetadataServiceName.name})"
         )
         .add(s"    extends ${clientServiceName.name} {")
         .indented(


### PR DESCRIPTION
`private[this]` was dropped from Scala 3: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html and it started generating warning about the generated code with Scala 3.4.