### PR TITLE
Update examples dependencies & scala-version

### DIFF
--- a/examples/fullapp/build.sbt
+++ b/examples/fullapp/build.sbt
@@ -1,12 +1,12 @@
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.13.14"
 
 ThisBuild / cancelable := true
 
 ThisBuild / connectInput := true
 
-val grpcVersion = "1.50.1"
+val grpcVersion = "1.64.0"
 
 lazy val protos = crossProject(JSPlatform, JVMPlatform)
   .in(file("protos"))

--- a/examples/fullapp/project/plugins.sbt
+++ b/examples/fullapp/project/plugins.sbt
@@ -2,17 +2,17 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 
-val zioGrpcVersion = "0.6.1"
+val zioGrpcVersion = "0.6.2"
 
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % zioGrpcVersion,
-  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.7"
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.15"
 )
 
 // For Scala.js:
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 

--- a/examples/helloworld/build.sbt
+++ b/examples/helloworld/build.sbt
@@ -1,8 +1,8 @@
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.14"
 
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val grpcVersion = "1.50.1"
+val grpcVersion = "1.64.0"
 
 Compile / PB.targets := Seq(
   scalapb.gen(grpc = true) -> (Compile / sourceManaged).value,

--- a/examples/helloworld/project/plugins.sbt
+++ b/examples/helloworld/project/plugins.sbt
@@ -2,11 +2,11 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 
-val zioGrpcVersion = "0.6.1"
+val zioGrpcVersion = "0.6.2"
 
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % zioGrpcVersion,
-  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.10"
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.15"
 )

--- a/examples/routeguide/build.sbt
+++ b/examples/routeguide/build.sbt
@@ -1,8 +1,8 @@
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.14"
 
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val grpcVersion = "1.50.1"
+val grpcVersion = "1.64.0"
 
 Compile / PB.targets := Seq(
   scalapb.gen(grpc = true) -> (Compile / sourceManaged).value,

--- a/examples/routeguide/project/plugins.sbt
+++ b/examples/routeguide/project/plugins.sbt
@@ -8,5 +8,5 @@ val zioGrpcVersion = "0.6.1"
 
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % zioGrpcVersion,
-  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.10"
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.15"
 )

--- a/examples/routeguide/project/plugins.sbt
+++ b/examples/routeguide/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 
-val zioGrpcVersion = "0.6.1"
+val zioGrpcVersion = "0.6.2"
 
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % zioGrpcVersion,


### PR DESCRIPTION
I've just started messing around with zio-grpc (great work btw) and encountered some issues with the examples (all three). 

### 1: A compiler error 
It's caused by `compiler-bridge`, to fix this I had to update to Scala to `2.13.14`.

<details><summary>Error encountered in SBT</summary>

```
[IJ]reload
[info] welcome to sbt 1.9.0 (Amazon.com Inc. Java 22)
[info] loading global plugins from /Users/alexknight/.sbt/1.0/plugins
[info] loading settings for project helloworld-build from plugins.sbt,idea67.sbt ...
[info] loading project definition from /Users/alexknight/projects-github/zio-grpc/examples/helloworld/project
[info] loading settings for project helloworld from build.sbt ...
[info] set current project to helloworld (in build file:/Users/alexknight/projects-github/zio-grpc/examples/helloworld/)
[IJ]compile
[info] Compiling 1 protobuf files to /Users/alexknight/projects-github/zio-grpc/examples/helloworld/target/scala-2.13/src_managed/main
[info] compiling 11 Scala sources to /Users/alexknight/projects-github/zio-grpc/examples/helloworld/target/scala-2.13/classes ...
[info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.10. Compiling...
error:
  bad constant pool index: 0 at pos: 49180
     while compiling: <no file>
        during phase: globalPhase=<no phase>, enteringPhase=<some phase>
     library version: version 2.13.10
    compiler version: version 2.13.10
  reconstructed args: -bootclasspath /Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.10/scala-library-2.13.10.jar -nowarn -classpath /Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.9.0/compiler-interface-1.9.0.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.9.0/util-interface-1.9.0.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.13/1.9.0/compiler-bridge_2.13-1.9.0-sources.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.10/scala-compiler-2.13.10.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.10/scala-reflect-2.13.10.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.21.0/jline-3.21.0.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.9.0/jna-5.9.0.jar -d /var/folders/z7/0s6vlw9s6dj65wf93_qwdnp00000gn/T/sbt_6da37f9 -Xmaxwarns 0

  last tree to typer: EmptyTree
       tree position: <unknown>
            tree tpe: <notype>
              symbol: null
           call site: <none> in <none>

== Source file context for tree position ==

error: scala.reflect.internal.FatalError:
  bad constant pool index: 0 at pos: 49180
     while compiling: <no file>
        during phase: globalPhase=<no phase>, enteringPhase=<some phase>
     library version: version 2.13.10
    compiler version: version 2.13.10
  reconstructed args: -bootclasspath /Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.10/scala-library-2.13.10.jar -nowarn -classpath /Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.9.0/compiler-interface-1.9.0.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.9.0/util-interface-1.9.0.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.13/1.9.0/compiler-bridge_2.13-1.9.0-sources.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.10/scala-compiler-2.13.10.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.10/scala-reflect-2.13.10.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.21.0/jline-3.21.0.jar:/Users/alexknight/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.9.0/jna-5.9.0.jar -d /var/folders/z7/0s6vlw9s6dj65wf93_qwdnp00000gn/T/sbt_6da37f9 -Xmaxwarns 0

  last tree to typer: EmptyTree
       tree position: <unknown>
            tree tpe: <notype>
              symbol: null
           call site: <none> in <none>

== Source file context for tree position ==


	at scala.reflect.internal.Reporting.abort(Reporting.scala:69)
	at scala.reflect.internal.Reporting.abort$(Reporting.scala:65)
	at scala.reflect.internal.SymbolTable.abort(SymbolTable.scala:28)
	at scala.tools.nsc.symtab.classfile.ClassfileParser$ConstantPool.errorBadIndex(ClassfileParser.scala:408)
	at scala.tools.nsc.symtab.classfile.ClassfileParser$ConstantPool.getExternalName(ClassfileParser.scala:263)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.readParamNames$1(ClassfileParser.scala:842)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parseAttribute$1(ClassfileParser.scala:848)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parseAttributes$6(ClassfileParser.scala:925)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parseAttributes(ClassfileParser.scala:1497)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parseMethod(ClassfileParser.scala:625)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parseClass(ClassfileParser.scala:548)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parse$2(ClassfileParser.scala:175)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parse$1(ClassfileParser.scala:160)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parse(ClassfileParser.scala:143)
	at scala.tools.nsc.symtab.SymbolLoaders$ClassfileLoader.doComplete(SymbolLoaders.scala:342)
	at scala.tools.nsc.symtab.SymbolLoaders$SymbolLoader.$anonfun$complete$2(SymbolLoaders.scala:249)
	at scala.tools.nsc.symtab.SymbolLoaders$SymbolLoader.complete(SymbolLoaders.scala:247)
	at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1563)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1535)
	at scala.reflect.internal.Definitions.scala$reflect$internal$Definitions$$enterNewMethod(Definitions.scala:48)
	at scala.reflect.internal.Definitions$DefinitionsClass.String_$plus$lzycompute(Definitions.scala:1261)
	at scala.reflect.internal.Definitions$DefinitionsClass.String_$plus(Definitions.scala:1261)
	at scala.reflect.internal.Definitions$DefinitionsClass.syntheticCoreMethods$lzycompute(Definitions.scala:1583)
	at scala.reflect.internal.Definitions$DefinitionsClass.syntheticCoreMethods(Definitions.scala:1565)
	at scala.reflect.internal.Definitions$DefinitionsClass.symbolsNotPresentInBytecode$lzycompute(Definitions.scala:1596)
	at scala.reflect.internal.Definitions$DefinitionsClass.symbolsNotPresentInBytecode(Definitions.scala:1596)
	at scala.reflect.internal.Definitions$DefinitionsClass.init(Definitions.scala:1652)
	at scala.tools.nsc.Global$Run.<init>(Global.scala:1236)
	at scala.tools.nsc.Driver.doCompile(Driver.scala:47)
	at scala.tools.nsc.MainClass.doCompile(Main.scala:30)
	at scala.tools.nsc.Driver.process(Driver.scala:68)
	at scala.tools.nsc.Main.process(Main.scala)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at sbt.internal.inc.RawCompiler.getReporter$1(RawCompiler.scala:56)
	at sbt.internal.inc.RawCompiler.apply(RawCompiler.scala:77)
	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$7(AnalyzingCompiler.scala:457)
	at sbt.internal.inc.AnalyzingCompiler$.handleCompilationError$1(AnalyzingCompiler.scala:432)
	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$5(AnalyzingCompiler.scala:453)
	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$5$adapted(AnalyzingCompiler.scala:448)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:487)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:497)
	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$2(AnalyzingCompiler.scala:448)
	at sbt.internal.inc.AnalyzingCompiler$.$anonfun$compileSources$2$adapted(AnalyzingCompiler.scala:440)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:487)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:497)
	at sbt.internal.inc.AnalyzingCompiler$.compileSources(AnalyzingCompiler.scala:440)
	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$3(ZincComponentCompiler.scala:275)
	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$3$adapted(ZincComponentCompiler.scala:257)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:487)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:497)
	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$2(ZincComponentCompiler.scala:257)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at sbt.internal.util.BufferedLogger.bufferQuietly(BufferedLogger.scala:159)
	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$1(ZincComponentCompiler.scala:257)
	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compileAndInstall$1$adapted(ZincComponentCompiler.scala:254)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:487)
	at sbt.io.IO$.withTemporaryDirectory(IO.scala:497)
	at sbt.internal.inc.ZincComponentCompiler.compileAndInstall(ZincComponentCompiler.scala:254)
	at sbt.internal.inc.ZincComponentCompiler.$anonfun$compiledBridgeJar$1(ZincComponentCompiler.scala:222)
	at sbt.internal.inc.IfMissing$Define.run(IfMissing.scala:19)
	at sbt.internal.inc.ZincComponentManager.createAndCache$1(ZincComponentManager.scala:51)
	at sbt.internal.inc.ZincComponentManager.$anonfun$files$3(ZincComponentManager.scala:62)
	at sbt.internal.inc.ZincComponentManager.getOrElse$1(ZincComponentManager.scala:43)
	at sbt.internal.inc.ZincComponentManager.$anonfun$files$2(ZincComponentManager.scala:62)
	at sbt.internal.inc.ZincComponentManager$$anon$1.call(ZincComponentManager.scala:91)
	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:113)
	at xsbt.boot.Locks$GlobalLock.withChannelRetries$1(Locks.scala:91)
	at xsbt.boot.Locks$GlobalLock.$anonfun$withFileLock$1(Locks.scala:119)
	at xsbt.boot.Using$.withResource(Using.scala:12)
	at xsbt.boot.Using$.apply(Using.scala:9)
	at xsbt.boot.Locks$GlobalLock.withFileLock(Locks.scala:119)
	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:71)
	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:59)
	at xsbt.boot.Locks$.apply0(Locks.scala:47)
	at xsbt.boot.Locks$.apply(Locks.scala:36)
	at sbt.internal.inc.ZincComponentManager.lock(ZincComponentManager.scala:91)
	at sbt.internal.inc.ZincComponentManager.$anonfun$lockSecondaryCache$1(ZincComponentManager.scala:88)
	at scala.Option.map(Option.scala:230)
	at sbt.internal.inc.ZincComponentManager.lockSecondaryCache(ZincComponentManager.scala:88)
	at sbt.internal.inc.ZincComponentManager.fromSecondary$1(ZincComponentManager.scala:60)
	at sbt.internal.inc.ZincComponentManager.$anonfun$files$6(ZincComponentManager.scala:66)
	at sbt.internal.inc.ZincComponentManager.getOrElse$1(ZincComponentManager.scala:43)
	at sbt.internal.inc.ZincComponentManager.$anonfun$files$5(ZincComponentManager.scala:66)
	at sbt.internal.inc.ZincComponentManager$$anon$1.call(ZincComponentManager.scala:91)
	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:113)
	at xsbt.boot.Locks$GlobalLock.withChannelRetries$1(Locks.scala:91)
	at xsbt.boot.Locks$GlobalLock.$anonfun$withFileLock$1(Locks.scala:119)
	at xsbt.boot.Using$.withResource(Using.scala:12)
	at xsbt.boot.Using$.apply(Using.scala:9)
	at xsbt.boot.Locks$GlobalLock.withFileLock(Locks.scala:119)
	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:71)
	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:59)
	at xsbt.boot.Locks$.apply0(Locks.scala:47)
	at xsbt.boot.Locks$.apply(Locks.scala:36)
	at sbt.internal.inc.ZincComponentManager.lock(ZincComponentManager.scala:91)
	at sbt.internal.inc.ZincComponentManager.lockLocalCache(ZincComponentManager.scala:84)
	at sbt.internal.inc.ZincComponentManager.files(ZincComponentManager.scala:66)
	at sbt.internal.inc.ZincComponentManager.file(ZincComponentManager.scala:72)
	at sbt.internal.inc.ZincComponentCompiler.compiledBridgeJar(ZincComponentCompiler.scala:222)
	at sbt.internal.inc.ZincComponentCompiler$ZincCompilerBridgeProvider.compiledBridge(ZincComponentCompiler.scala:63)
	at sbt.internal.inc.ZincComponentCompiler$ZincCompilerBridgeProvider.fetchCompiledBridge(ZincComponentCompiler.scala:70)
	at sbt.internal.inc.AnalyzingCompiler.getDualLoader(AnalyzingCompiler.scala:354)
	at sbt.internal.inc.AnalyzingCompiler.getCompilerLoader(AnalyzingCompiler.scala:343)
	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:87)
	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$7(MixedAnalyzingCompiler.scala:193)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:248)
	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:183)
	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4$adapted(MixedAnalyzingCompiler.scala:163)
	at sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:239)
	at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:163)
	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:211)
	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:534)
	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:534)
	at sbt.internal.inc.Incremental$.$anonfun$apply$5(Incremental.scala:179)
	at sbt.internal.inc.Incremental$.$anonfun$apply$5$adapted(Incremental.scala:177)
	at sbt.internal.inc.Incremental$$anon$2.run(Incremental.scala:463)
	at sbt.internal.inc.IncrementalCommon$CycleState.next(IncrementalCommon.scala:116)
	at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:56)
	at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:52)
	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:263)
	at sbt.internal.inc.Incremental$.$anonfun$incrementalCompile$8(Incremental.scala:418)
	at sbt.internal.inc.Incremental$.withClassfileManager(Incremental.scala:505)
	at sbt.internal.inc.Incremental$.incrementalCompile(Incremental.scala:405)
	at sbt.internal.inc.Incremental$.apply(Incremental.scala:171)
	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:534)
	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:488)
	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:332)
	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:425)
	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:137)
	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:2366)
	at sbt.Defaults$.$anonfun$compileIncrementalTask$2(Defaults.scala:2316)
	at sbt.internal.server.BspCompileTask$.$anonfun$compute$1(BspCompileTask.scala:30)
	at sbt.internal.io.Retry$.apply(Retry.scala:46)
	at sbt.internal.io.Retry$.apply(Retry.scala:28)
	at sbt.internal.io.Retry$.apply(Retry.scala:23)
	at sbt.internal.server.BspCompileTask$.compute(BspCompileTask.scala:30)
	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:2314)
	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
	at sbt.Execute.work(Execute.scala:291)
	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
[info] Attempting to fetch org.scala-sbt:compiler-bridge_2.13:1.9.0.
[error] (Compile / compileIncremental) Error compiling the sbt component 'compiler-bridge_2.13'
[error] Total time: 3 s, completed 20 May 2024, 23:53:05
[IJ]
```

</details>

### 2: `ServerMain.serverLive` failing silently
I noticed the Server applications were exiting immediately. To investigate this, I added the following to every main:
```scala
  override def run: URIO[Any, ExitCode] = for {
    _ <- myAppLogic.orDie
  } yield ExitCode.success
```
Which yielded the stack trace below. To fix this, I bumped `grpc-netty` to `1.64.0`.
(There might be another issue around the fact the error wasn't originally logged.)

<details><summary>Resulting error from <code>orDie</code></summary>

```
[info] running (fork) zio_grpc.examples.routeguide.RouteGuideServer 
[info] Server is running on port 8980. Press Ctrl-C to stop.
[info] timestamp=2024-05-21T07:23:01.487933Z level=ERROR thread=#zio-fiber-1 message="" cause="Exception in thread "zio-fiber-4" java.util.ServiceConfigurationError: io.grpc.ServerProvider: io.grpc.netty.NettyServerProvider Unable to get public no-arg constructor
[info] 	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:586)
[info] 	at java.base/java.util.ServiceLoader.getConstructor(ServiceLoader.java:679)
[info] 	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1240)
[info] 	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
[info] 	at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
[info] 	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
[info] 	at io.grpc.ServiceProviders.getCandidatesViaServiceLoader(ServiceProviders.java:111)
[info] 	at io.grpc.ServiceProviders.loadAll(ServiceProviders.java:64)
[info] 	at io.grpc.ServerRegistry.getDefaultRegistry(ServerRegistry.java:94)
[info] 	at io.grpc.ServerProvider.provider(ServerProvider.java:42)
[info] 	at io.grpc.ServerBuilder.forPort(ServerBuilder.java:44)
[info] 	at scalapb.zio_grpc.ServerMain.builder(ServerMain.scala:19)
[info] 	at scalapb.zio_grpc.ServerMain.builder$(ServerMain.scala:19)
[info] 	at zio_grpc.examples.routeguide.RouteGuideServer$.builder(RouteGuideServer.scala:154)
[info] 	at scalapb.zio_grpc.ServerMain.$anonfun$serverLive$1(ServerMain.scala:21)
[info] 	at scalapb.zio_grpc.ScopedServer$.$anonfun$fromServiceListScoped$1(Server.scala:121)
[info] 	at zio.ZIO.$anonfun$map$2(ZIO.scala:960)
[info] 	at scalapb.zio_grpc.ScopedServer.fromServiceListScoped(Server.scala:118)
[info] 	at scalapb.zio_grpc.ServerLayer.fromServiceList(Server.scala:47)
[info] 	at scalapb.zio_grpc.ServerMain.myAppLogic(ServerMain.scala:23)
[info] 	at zio_grpc.examples.routeguide.RouteGuideServer.run(RouteGuideServer.scala:169)
[info] 	at scalapb.zio_grpc.ServerMain.myAppLogic(ServerMain.scala:23)
[info] 	at zio_grpc.examples.routeguide.RouteGuideServer.run(RouteGuideServer.scala:169)
[info] 	Suppressed: java.lang.NoClassDefFoundError: io/grpc/internal/AbstractServerImplBuilder
[info] 		at java.base/java.lang.ClassLoader.defineClass1(Native Method)
[info] 		at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027)
[info] 		at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
[info] 		at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
[info] 		at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
[info] 		at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
[info] 		at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
[info] 		at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
[info] 		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
[info] 		at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
[info] 		at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3549)
[info] 		at java.base/java.lang.Class.getConstructor0(Class.java:3754)
[info] 		at java.base/java.lang.Class.getConstructor(Class.java:2442)
[info] 		at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:666)
[info] 		at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:663)
[info] 		at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
[info] 		at java.base/java.util.ServiceLoader.getConstructor(ServiceLoader.java:674)
[info] 		at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1240)
[info] 		at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
[info] 		at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
[info] 		at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
[info] 		at io.grpc.ServiceProviders.getCandidatesViaServiceLoader(ServiceProviders.java:111)
[info] 		at io.grpc.ServiceProviders.loadAll(ServiceProviders.java:64)
[info] 		at io.grpc.ServerRegistry.getDefaultRegistry(ServerRegistry.java:94)
[info] 		at io.grpc.ServerProvider.provider(ServerProvider.java:42)
[info] 		at io.grpc.ServerBuilder.forPort(ServerBuilder.java:44)
[info] 		at scalapb.zio_grpc.ServerMain.builder(ServerMain.scala:19)
[info] 		at scalapb.zio_grpc.ServerMain.builder$(ServerMain.scala:19)
[info] 		at zio_grpc.examples.routeguide.RouteGuideServer$.builder(RouteGuideServer.scala:154)
[info] 		at scalapb.zio_grpc.ServerMain.$anonfun$serverLive$1(ServerMain.scala:21)
[info] 		at scalapb.zio_grpc.ScopedServer$.$anonfun$fromServiceListScoped$1(Server.scala:121)
[info] 		at zio.ZIO.$anonfun$map$2(ZIO.scala:960)
[info] 		Suppressed: java.lang.ClassNotFoundException: io.grpc.internal.AbstractServerImplBuilder
[info] 			at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
[info] 			at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
[info] 			at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
[info] 			at java.base/java.lang.ClassLoader.defineClass1(Native Method)
[info] 			at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027)
[info] 			at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
[info] 			at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
[info] 			at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
[info] 			at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
[info] 			at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
[info] 			at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
[info] 			at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
[info] 			at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
[info] 			at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3549)
[info] 			at java.base/java.lang.Class.getConstructor0(Class.java:3754)
[info] 			at java.base/java.lang.Class.getConstructor(Class.java:2442)
[info] 			at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:666)
[info] 			at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:663)
[info] 			at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
[info] 			at java.base/java.util.ServiceLoader.getConstructor(ServiceLoader.java:674)
[info] 			at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1240)
[info] 			at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
[info] 			at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
[info] 			at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
[info] 			at io.grpc.ServiceProviders.getCandidatesViaServiceLoader(ServiceProviders.java:111)
[info] 			at io.grpc.ServiceProviders.loadAll(ServiceProviders.java:64)
[info] 			at io.grpc.ServerRegistry.getDefaultRegistry(ServerRegistry.java:94)
[info] 			at io.grpc.ServerProvider.provider(ServerProvider.java:42)
[info] 			at io.grpc.ServerBuilder.forPort(ServerBuilder.java:44)
[info] 			at scalapb.zio_grpc.ServerMain.builder(ServerMain.scala:19)
[info] 			at scalapb.zio_grpc.ServerMain.builder$(ServerMain.scala:19)
[info] 			at zio_grpc.examples.routeguide.RouteGuideServer$.builder(RouteGuideServer.scala:154)
[info] 			at scalapb.zio_grpc.ServerMain.$anonfun$serverLive$1(ServerMain.scala:21)
[info] 			at scalapb.zio_grpc.ScopedServer$.$anonfun$fromServiceListScoped$1(Server.scala:121)
[info] 			at zio.ZIO.$anonfun$map$2(ZIO.scala:960)"
[error] Nonzero exit code returned from runner: 1
```

</details>

---
Additionally, I bumped the following dependencies (minor bump I imagine should be okay?):

1. `zio-grpc-codegen` from `0.6.1` -> `0.6.2`
2. `sbt-protoc` from `1.0.6` -> `1.0.7`
3. (`scalapb`) `compilerplugin` from `0.11.10` -> `0.11.15`

Might be related to #592?