### PR TITLE
Fix client connection leak on non-failure, non-interruption cases

### DIFF
--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -116,7 +116,10 @@ object ClientCalls {
 
   def exitHandler[Req, Res](
       call: ZClientCall[Req, Res]
-  )(l: Any, ex: Exit[StatusException, Any]) = anyExitHandler(call)(l, ex)
+  )(l: Any, ex: Exit[StatusException, Any]) =
+    ZIO.when(!ex.isSuccess) {
+      anyExitHandler(call)(l, ex)
+    }
 
   // less type safe
   def anyExitHandler[Req, Res](

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -122,8 +122,7 @@ object ClientCalls {
   def anyExitHandler[Req, Res](
       call: ZClientCall[Req, Res]
   ) =
-    (_: Any, ex: Exit[Any, Any]) =>
-      call.cancel("Interrupted").ignore
+    (_: Any, ex: Exit[Any, Any]) => call.cancel("Interrupted").ignore
 
   def unaryCall[Req, Res](
       channel: ZChannel,

--- a/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
+++ b/core/src/main/scalajvm/scalapb/zio_grpc/client/ClientCalls.scala
@@ -123,9 +123,7 @@ object ClientCalls {
       call: ZClientCall[Req, Res]
   ) =
     (_: Any, ex: Exit[Any, Any]) =>
-      ZIO.when(!ex.isSuccess) {
-        call.cancel("Interrupted").ignore
-      }
+      call.cancel("Interrupted").ignore
 
   def unaryCall[Req, Res](
       channel: ZChannel,


### PR DESCRIPTION
When using client streaming, if the stream is ended because of `.take`, `.runHead` or even `.interruptWhen`, the `exit` value in `anyExitHandler` is `Success`, not a failure or an interruption. In that case the underlying connection is not cancelled and could stay there forever.

As a fix, I moved the check of `isSuccess` to the method used for non-streaming cases, and in streaming cases we will always call `cancel`.